### PR TITLE
Don't try to register a user with RavenDB if credentials were provided explicitly

### DIFF
--- a/src/NServiceBus.RavenDB.Tests/Persistence/RavenUserInstallerTests.cs
+++ b/src/NServiceBus.RavenDB.Tests/Persistence/RavenUserInstallerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using NServiceBus.RavenDB.Persistence;
 using NUnit.Framework;
 using Raven.Client.Document;
@@ -58,6 +59,25 @@ public class RavenUserInstallerTests
 
             var actual = existing.DataAsJson.ToString().Replace("\r", String.Empty);
             Assert.AreEqual(expected, actual);
+        }
+    }
+
+    [Test]
+    public void EnsureUserIsNotAddedIfCredentialsAreProvidedExplicitly()
+    {
+        using (var documentStore = new EmbeddableDocumentStore
+        {
+            RunInMemory = true,
+            Credentials = new NetworkCredential("foo", "bar"),
+        })
+        {
+            documentStore.Initialize();
+            RavenUserInstaller.AddUserToDatabase(@"domain\user", documentStore);
+            var systemCommands = documentStore
+                .DatabaseCommands
+                .ForSystemDatabase();
+            var existing = systemCommands.Get("Raven/Authorization/WindowsSettings");
+            Assert.IsNull(existing);
         }
     }
 }

--- a/src/NServiceBus.RavenDB/Internal/RavenUserInstaller.cs
+++ b/src/NServiceBus.RavenDB/Internal/RavenUserInstaller.cs
@@ -55,7 +55,7 @@ namespace NServiceBus.RavenDB.Persistence
             var credentials = documentStore.Credentials as NetworkCredential;
             if (credentials != null && !string.IsNullOrWhiteSpace(credentials.UserName) && !string.IsNullOrWhiteSpace(credentials.Password))
             {
-                logger.InfoFormat("Skipping adding user '{0}' to RavenDB, because credentials were provided: {1}", identity, credentials);
+                logger.InfoFormat("Skipping adding user '{0}' to RavenDB, because credentials were provided via connection string", identity);
                 return;
             }
 

--- a/src/NServiceBus.RavenDB/Internal/RavenUserInstaller.cs
+++ b/src/NServiceBus.RavenDB/Internal/RavenUserInstaller.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.RavenDB.Persistence
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Net;
     using System.Reflection;
     using Raven.Abstractions.Data;
     using Raven.Abstractions.Extensions;
@@ -51,7 +52,14 @@ namespace NServiceBus.RavenDB.Persistence
         {
             var database = documentStore.DefaultDatabase ?? "<system>";
 
-            logger.InfoFormat(string.Format("Adding user '{0}' to raven. Instance:'{1}', Database:'{2}'.", identity, documentStore.Url, database));
+            var credentials = documentStore.Credentials as NetworkCredential;
+            if (credentials != null && !string.IsNullOrWhiteSpace(credentials.UserName) && !string.IsNullOrWhiteSpace(credentials.Password))
+            {
+                logger.InfoFormat("Skipping adding user '{0}' to RavenDB, because credentials were provided: {1}", identity, credentials);
+                return;
+            }
+
+            logger.Info(string.Format("Adding user '{0}' to raven. Instance:'{1}', Database:'{2}'.", identity, documentStore.Url, database));
 
             var systemCommands = documentStore
                 .DatabaseCommands


### PR DESCRIPTION
RavenUserInstaller should check if connection string has username supplied