### PR TITLE
RavenDB 3.0 testing

### DIFF
--- a/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
+++ b/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
@@ -109,6 +109,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Persistence\RavenUserInstallerTests.cs" />
+    <Compile Include="Persistence\TestConnectionVerifier.cs" />
     <Compile Include="RavenTestBase.cs" />
     <Compile Include="SagaPersister\Saga_with_unique_property_set_to_null.cs" />
     <Compile Include="SagaPersister\When_completing_a_saga_with_the_raven_persister.cs" />

--- a/src/NServiceBus.RavenDB.Tests/Persistence/TestConnectionVerifier.cs
+++ b/src/NServiceBus.RavenDB.Tests/Persistence/TestConnectionVerifier.cs
@@ -1,0 +1,39 @@
+﻿namespace NServiceBus.RavenDB.Tests.Persistence
+{
+    using NServiceBus.RavenDB.Internal;
+    using NUnit.Framework;
+    using Raven.Client.Document;
+
+    public class TestConnectionVerifier
+    {
+        [Test, Explicit("Should only be executed when the RavenDB instance listening on port 8080 is version 3.0")]
+        public void Doesnt_throw_on_ravendb3_server()
+        {
+            using (var documentStore = new DocumentStore
+            {
+                Url = "http://localhost:8080",
+                DefaultDatabase = "Test"
+            })
+            {
+                documentStore.Initialize();
+
+                ConnectionVerifier.VerifyConnectionToRavenDBServer(documentStore);
+            }
+        }
+
+        [Test, Explicit("Should only be executed when the RavenDB instance listening on port 8080 is version 2.5")]
+        public void Doesnt_throw_on_ravendb25_server()
+        {
+            using (var documentStore = new DocumentStore
+            {
+                Url = "http://localhost:8080",
+                DefaultDatabase = "Test"
+            })
+            {
+                documentStore.Initialize();
+
+                ConnectionVerifier.VerifyConnectionToRavenDBServer(documentStore);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB/Internal/ConnectionVerifier.cs
+++ b/src/NServiceBus.RavenDB/Internal/ConnectionVerifier.cs
@@ -89,7 +89,8 @@
                 int buildVersion;
                 if (!int.TryParse(BuildVersion, out buildVersion))
                     return false;
-                return !string.IsNullOrEmpty(ProductVersion) && ProductVersion.StartsWith("2.5") && buildVersion >= 2900;
+                return !string.IsNullOrEmpty(ProductVersion) &&
+                       (ProductVersion.StartsWith("2.5") && buildVersion >= 2900) || (ProductVersion.StartsWith("3.0"));
             }
 
             public override string ToString()


### PR DESCRIPTION
I'm trying to see if we can support RavenDB 3.0 fully without upgrading the client libraries to 2.5 (because 3.0 client doesn't support 2.5 servers). If this is doable I think it'd make most sense as a first step, and then we can increment a major version and release NSB.RavenDB with RavenDB 3.0 client libraries

On a related note, I would like to have a RavenDB 3.0 instance running on the build server on a dedicated port, so we can run the NSB.RavenDB test suite against it as well. @gbiellem can we do that (we did this before for 2.0 and 2.5)? Then we can go ahead and make https://github.com/Particular/NServiceBus.RavenDB/commit/e43cda73f3b6b9b012b35a42fa1df9cbf56949c1#diff-1 run all the time with the correct ports.

@andreasohlund @SimonCropp @johnsimons thoughts?