### PR TITLE
Safer way to add indexes to RavenDB by modules needing them

### DIFF
--- a/src/NServiceBus.RavenDB/Internal/Helpers.cs
+++ b/src/NServiceBus.RavenDB/Internal/Helpers.cs
@@ -9,6 +9,7 @@
     using NServiceBus.Persistence;
     using Raven.Client;
     using Raven.Client.Document;
+    using Raven.Client.Indexes;
     using Raven.Json.Linq;
     using Settings;
 
@@ -127,6 +128,27 @@
                 var hashBytes = provider.ComputeHash(inputBytes);
                 // generate a guid from the hash:
                 return new Guid(hashBytes);
+            }
+        }
+
+        /// <summary>
+        /// Safely add the index to the RavenDB database, protect against possible failures caused by documented
+        /// and undocumented possibilities of failure.
+        /// Will throw iff index registration failed and index doesn't exist or it exists but with a non-current definition.
+        /// </summary>
+        /// <param name="store"></param>
+        /// <param name="index"></param>
+        internal static void SafelyCreateIndex(IDocumentStore store, AbstractIndexCreationTask index)
+        {
+            try
+            {
+                index.Execute(store);
+            }
+            catch (Exception) // Apparently ArgumentException can be thrown as well as a WebException; not taking any chances
+            {
+                var existingIndex = store.DatabaseCommands.GetIndex(index.IndexName);
+                if (existingIndex == null || !index.CreateIndexDefinition().Equals(existingIndex))
+                    throw;
             }
         }
     }

--- a/src/NServiceBus.RavenDB/Timeouts/RavenDbTimeoutStorage.cs
+++ b/src/NServiceBus.RavenDB/Timeouts/RavenDbTimeoutStorage.cs
@@ -43,7 +43,7 @@
                 remoteStorage.TransactionRecoveryStorage = new IsolatedStorageTransactionRecoveryStorage();
             }
 
-            new TimeoutsIndex().Execute(store);
+            Helpers.SafelyCreateIndex(store, new TimeoutsIndex());
 
             context.Container.ConfigureComponent<Installer>(DependencyLifecycle.InstancePerCall)
                 .ConfigureProperty(c => c.StoreToInstall, store);


### PR DESCRIPTION
RavenDB seems to behave abnormally when trying to register indexes with it concurrently. This is a known issue with Embedded instances (was raised before and got a Won't Fix response https://groups.google.com/forum/#!topic/ravendb/IrMqmgPyrGo), and apparently this also happens with client / server setups. The latter case was reported as http://issues.hibernatingrhinos.com/issue/RavenDB-3311.

This fix adds protective coding measures to protect against crashing when RavenDB behaves abnormally when trying to register indexes, and also any other possible failure.

I could have made it retry, but instead I'm assuming the failure was due to RavenDB trying to add the same index at the same time from different process (and not just because PutIndex is called concurrently) - in which case one of the calls will succeed and therefore we should be expecting to rethrow unless indeed something bad happened.

Please review @danielmarbach @johnsimons 