### PR TITLE
Use DeleteByIndex instead of streaming

### DIFF
--- a/src/NServiceBus.RavenDB/Timeouts/TimeoutPersister.cs
+++ b/src/NServiceBus.RavenDB/Timeouts/TimeoutPersister.cs
@@ -4,7 +4,6 @@ namespace NServiceBus.TimeoutPersisters.RavenDB
     using System.Collections.Generic;
     using System.Linq;
     using NServiceBus.Timeout.Core;
-    using Raven.Abstractions.Commands;
     using Raven.Abstractions.Data;
     using Raven.Client;
     using Raven.Client.Linq;
@@ -114,23 +113,8 @@ namespace NServiceBus.TimeoutPersisters.RavenDB
 
         public void RemoveTimeoutBy(Guid sagaId)
         {
-            using (var session = DocumentStore.OpenSession())
-            {
-                session.Advanced.UseOptimisticConcurrency = true;
-
-                var query = session.Query<Timeout, TimeoutsIndex>().Where(x => x.SagaId == sagaId).Select(x => x.Id);
-                using (var enumerator = session.Advanced.Stream(query))
-                {
-                    while (enumerator.MoveNext())
-                    {
-                        session.Advanced.Defer(new DeleteCommandData
-                        {
-                            Key = enumerator.Current.Key
-                        });
-                    }
-                }
-                session.SaveChanges();
-            }
+            var operation = DocumentStore.DatabaseCommands.DeleteByIndex("TimeoutsIndex", new IndexQuery { Query = string.Format("SagaId:{0}", sagaId) }, new BulkOperationOptions { AllowStale = true });
+            operation.WaitForCompletion();
         }
 
         IRavenQueryable<Timeout> GetChunkQuery(IDocumentSession session)


### PR DESCRIPTION
This optimization has the biggest impact when there are a lot of sagas with timeouts. My test harness was a bit unrealistic I confess. I added 1000 timeouts to the same saga and then completed the saga. Nonetheless, the removal with streaming is high CPU intense. This removes that problem entirely.

### Before

![image](https://cloud.githubusercontent.com/assets/174258/7536837/b8026476-f593-11e4-98f2-1b2b3f8801e8.png)

### After
![image](https://cloud.githubusercontent.com/assets/174258/7536843/c9446c84-f593-11e4-8f76-c520f056daa7.png)

I made the following assumptions

`session.Advanced.UseOptimisticConcurrency = true;`

is actually not really needed because the only thing which can happen in parallel is `TryRemove` and `RemoveTimeoutBy(sagaId)` and in that case we are deleting and therefore we don't care. Not sure about outbox scenarios. But the ATTs are passing. 

@Particular/engineers please review