### PR TITLE
implement IPersistTimeoutsV2 interface

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -55,9 +55,11 @@
 *.fs text
 *.fsx text
 *.hs text
-
+*.targets text
 *.psm1 text
 *.ps1 text
+*.md text
+*.DotSettings text
 *.txt text eol=crlf
 *.bat text eol=crlf
 

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ installer/ServiceControl-cache
 *.user
 *.userosscache
 *.sln.docstates
+.vs/
+
+# mac temp file ignore
+.DS_Store
 
 # Build results
 [Dd]ebug/
@@ -75,3 +79,7 @@ _ReSharper*/
 *.[Rr]e[Ss]harper
 *.DotSettings.user
 
+src/scaffolding.config
+
+# Approval tests temp file
+*.received.*

--- a/packaging/nuget/nservicebus.ravendb.nuspec
+++ b/packaging/nuget/nservicebus.ravendb.nuspec
@@ -15,7 +15,7 @@
     <copyright>$copyright$</copyright>
     <tags>nservicebus servicebus msmq cqrs publish subscribe ravendb</tags>
     <dependencies>
-      <dependency id="NServiceBus" version="[5.0.0, 6.0.0)" />
+      <dependency id="NServiceBus" version="[5.2.8, 6.0.0)" />
       <dependency id="RavenDB.Client" version="[3.0.3800, 4.0.0)" />
     </dependencies>
   </metadata>

--- a/src/NServiceBus.RavenDB.AcceptanceTests/NServiceBus.RavenDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/NServiceBus.RavenDB.AcceptanceTests.csproj
@@ -40,8 +40,8 @@
       <HintPath>..\packages\NServiceBus.AcceptanceTesting.5.2.1\lib\net45\NServiceBus.AcceptanceTesting.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NServiceBus.5.2.1\lib\net45\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.5.2.8\lib\net45\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>

--- a/src/NServiceBus.RavenDB.AcceptanceTests/packages.config
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NServiceBus" version="5.2.1" targetFramework="net45" />
+  <package id="NServiceBus" version="5.2.8" targetFramework="net45" />
   <package id="NServiceBus.AcceptanceTesting" version="5.2.1" targetFramework="net45" />
   <package id="NServiceBus.AcceptanceTests.Sources" version="5.2.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />

--- a/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
+++ b/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
@@ -37,8 +37,8 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="NServiceBus.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NServiceBus.5.2.1\lib\net45\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.5.2.8\lib\net45\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>

--- a/src/NServiceBus.RavenDB.Tests/Timeouts/When_removing_timeouts_from_the_storage.cs
+++ b/src/NServiceBus.RavenDB.Tests/Timeouts/When_removing_timeouts_from_the_storage.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 
 namespace NServiceBus.RavenDB.Tests.Timeouts
 {
+    using System.Linq;
     using NUnit.Framework;
     using Support;
     using TimeoutPersisters.RavenDB;
@@ -10,139 +11,117 @@ namespace NServiceBus.RavenDB.Tests.Timeouts
     using Timeout = TimeoutPersisters.RavenDB.TimeoutData;
 
     [TestFixture]
-    [Ignore("These tests currently operate under the assumption TimeoutData.Id gets assigned by the persistence layer; need to revisit this")]
     class When_removing_timeouts_from_the_storage:RavenDBPersistenceTestBase
     {
-        [Test]
-        public void Should_return_the_correct_headers()
+        TimeoutPersister timeoutPersister;
+        TimeoutData timeoutWithHeaders = GetTimeoutWithHeaders();
+
+        [SetUp]
+        public void SetUpTests()
         {
-            var persister = new TimeoutPersister
+            new TimeoutsIndex().Execute(store);
+            timeoutPersister = new TimeoutPersister
             {
                 DocumentStore = store,
                 EndpointName = "MyTestEndpoint",
             };
+        }
 
-            var headers = new Dictionary<string, string>
-                          {
-                              {"Bar", "34234"},
-                              {"Foo", "aString1"},
-                              {"Super", "aString2"}
-                          };
+        [Test]
+        public void Should_return_the_correct_headers()
+        {
+            timeoutPersister.Add(timeoutWithHeaders);
 
-            var timeout = new TimeoutData
-            {
-                Time = DateTime.UtcNow.AddHours(-1),
-                Destination = new Address("timeouts", RuntimeEnvironment.MachineName),
-                SagaId = Guid.NewGuid(),
-                State = new byte[] { 1, 1, 133, 200 },
-                Headers = headers,
-                OwningTimeoutManager = "MyTestEndpoint",
-            };
-            persister.Add(timeout);
+            var timeouts = GetTimeouts();
+            Assert.AreEqual(1, timeouts.Count());
 
             TimeoutData timeoutData;
-            persister.TryRemove(timeout.Id, out timeoutData);
+            timeoutPersister.TryRemove(timeouts.First().Item1, out timeoutData);
 
-            CollectionAssert.AreEqual(headers, timeoutData.Headers);
+            CollectionAssert.AreEqual(new Dictionary<string, string>
+            {
+                {"Bar", "34234"},
+                {"Foo", "aString1"},
+                {"Super", "aString2"}
+            }, timeoutData.Headers);
         }
 
         [Test]
         public void Should_remove_timeouts_by_id()
         {
-            new TimeoutsIndex().Execute(store);
-
-            var persister = new TimeoutPersister
-            {
-                DocumentStore = store,
-                EndpointName = "MyTestEndpoint",
-            };
-
-            var t1 = new TimeoutData
-            {
-                Time = DateTime.Now.AddYears(-1),
-                OwningTimeoutManager = "MyTestEndpoint",
-                Headers = new Dictionary<string, string>
-                                   {
-                                       {"Header1", "Value1"}
-                                   }
-            };
-            var t2 = new TimeoutData
-            {
-                Time = DateTime.Now.AddYears(-1),
-                OwningTimeoutManager = "MyTestEndpoint",
-                Headers = new Dictionary<string, string>
-                                   {
-                                       {"Header1", "Value1"}
-                                   }
-            };
-
-            persister.Add(t1);
-            persister.Add(t2);
-
-            WaitForIndexing(store);
-
-            DateTime nextTimeToRunQuery;
-            var timeouts = persister.GetNextChunk(DateTime.UtcNow.AddYears(-3), out nextTimeToRunQuery);
+            timeoutPersister.Add(timeoutWithHeaders);
+            timeoutPersister.Add(timeoutWithHeaders);
+            
+            var timeouts = GetTimeouts();
+            Assert.AreEqual(2, timeouts.Count());
 
             foreach (var timeout in timeouts)
             {
                 TimeoutData timeoutData;
-                persister.TryRemove(timeout.Item1, out timeoutData);
+                timeoutPersister.TryRemove(timeout.Item1, out timeoutData);
             }
 
-            using (var session = store.OpenSession())
-            {
-                Assert.Null(session.Load<Timeout>(new Guid(t1.Id)));
-                Assert.Null(session.Load<Timeout>(new Guid(t2.Id)));
-            }
+            AssertAllTimeoutsHaveBeenRemoved(timeouts);
         }
 
         [Test]
         public void Should_remove_timeouts_by_sagaid()
         {
-            new TimeoutsIndex().Execute(store);
-
-            var persister = new TimeoutPersister
-            {
-                DocumentStore = store,
-                EndpointName = "MyTestEndpoint",
-            };
-
             var sagaId1 = Guid.NewGuid();
             var sagaId2 = Guid.NewGuid();
-            var t1 = new TimeoutData
-            {
-                SagaId = sagaId1,
-                Time = DateTime.Now.AddYears(1),
-                OwningTimeoutManager = "MyTestEndpoint",
-                Headers = new Dictionary<string, string>
-                                   {
-                                       {"Header1", "Value1"}
-                                   }
-            };
-            var t2 = new TimeoutData
-            {
-                SagaId = sagaId2,
-                Time = DateTime.Now.AddYears(1),
-                OwningTimeoutManager = "MyTestEndpoint",
-                Headers = new Dictionary<string, string>
-                                   {
-                                       {"Header1", "Value1"}
-                                   }
-            };
 
-            persister.Add(t1);
-            persister.Add(t2);
+            timeoutPersister.Add(GetTimeoutWithSagaId(sagaId1));
+            timeoutPersister.Add(GetTimeoutWithSagaId(sagaId2));
+            
+            var timeouts = GetTimeouts();
+            Assert.AreEqual(2, timeouts.Count());
 
+            timeoutPersister.RemoveTimeoutBy(sagaId1);
+            timeoutPersister.RemoveTimeoutBy(sagaId2);
+
+            AssertAllTimeoutsHaveBeenRemoved(timeouts);
+        }
+
+        static TimeoutData GetTimeoutWithHeaders()
+        {
+            return new TimeoutData
+            {
+                Time = DateTime.UtcNow.AddYears(-1),
+                Destination = new Address("timeouts", RuntimeEnvironment.MachineName),
+                SagaId = Guid.NewGuid(),
+                State = new byte[] { 1, 1, 133, 200 },
+                Headers = new Dictionary<string, string>
+                {
+                    {"Bar", "34234"},
+                    {"Foo", "aString1"},
+                    {"Super", "aString2"}
+                },
+                OwningTimeoutManager = "MyTestEndpoint",
+            };
+        }
+
+        TimeoutData GetTimeoutWithSagaId(Guid sagaId)
+        {
+            timeoutWithHeaders.SagaId = sagaId;
+            return timeoutWithHeaders;
+        }
+
+        List<Tuple<string, DateTime>> GetTimeouts()
+        {
             WaitForIndexing(store);
+            DateTime nextRun;
+            var timeouts = timeoutPersister.GetNextChunk(DateTime.Now.AddYears(-3), out nextRun).ToList();
+            return timeouts;
+        }
 
-            persister.RemoveTimeoutBy(sagaId1);
-            persister.RemoveTimeoutBy(sagaId2);
-
-            using (var session = store.OpenSession())
+        void AssertAllTimeoutsHaveBeenRemoved(List<Tuple<string, DateTime>> timeouts)
+        {
+            foreach (var timeout in timeouts)
             {
-                Assert.Null(session.Load<Timeout>(new Guid(t1.Id)));
-                Assert.Null(session.Load<Timeout>(new Guid(t2.Id)));
+                using (var session = store.OpenSession())
+                {
+                    Assert.Null(session.Load<Timeout>(timeout.Item1));
+                }
             }
         }
     }

--- a/src/NServiceBus.RavenDB.Tests/packages.config
+++ b/src/NServiceBus.RavenDB.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NServiceBus" version="5.2.1" targetFramework="net45" />
+  <package id="NServiceBus" version="5.2.8" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
   <package id="RavenDB.Client" version="3.0.3800" targetFramework="net45" />
   <package id="RavenDB.Database" version="3.0.3800" targetFramework="net45" />

--- a/src/NServiceBus.RavenDB.sln.DotSettings
+++ b/src/NServiceBus.RavenDB.sln.DotSettings
@@ -1,6 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 
-	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp50</s:String>
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp60</s:String>
 	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/CodeCompletion/AutoCompleteBasicCompletion/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/CodeCompletion/IntelliSenseCompletingCharacters/IntelliSenseCompletingCharactersSettingCSharp/UpgradedFromVSSettings/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/LookupWindow/ShowSummary/@EntryValue">True</s:Boolean>

--- a/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
+++ b/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
@@ -46,8 +46,8 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="NServiceBus.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NServiceBus.5.2.1\lib\net45\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.5.2.8\lib\net45\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Raven.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
       <HintPath>..\packages\RavenDB.Client.3.0.3800\lib\net45\Raven.Abstractions.dll</HintPath>

--- a/src/NServiceBus.RavenDB/packages.config
+++ b/src/NServiceBus.RavenDB/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GitVersionTask" version="2.0.1" targetFramework="net45" />
-  <package id="NServiceBus" version="5.2.1" targetFramework="net45" />
+  <package id="NServiceBus" version="5.2.8" targetFramework="net45" />
   <package id="NuGetPackager" version="0.5.5" targetFramework="net45" />
   <package id="RavenDB.Client" version="3.0.3800" targetFramework="net45" />
 </packages>

--- a/src/Sample/Sample.csproj
+++ b/src/Sample/Sample.csproj
@@ -35,8 +35,8 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="NServiceBus.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NServiceBus.5.2.1\lib\net45\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.5.2.8\lib\net45\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Raven.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
       <HintPath>..\packages\RavenDB.Client.3.0.3800\lib\net45\Raven.Abstractions.dll</HintPath>

--- a/src/Sample/packages.config
+++ b/src/Sample/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NServiceBus" version="5.2.1" targetFramework="net45" />
+  <package id="NServiceBus" version="5.2.8" targetFramework="net45" />
   <package id="RavenDB.Client" version="3.0.3800" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
## Who's affected

You might be affected if you are using one of the following transport configurations:
* RabbitMQ transport
* Azure transport 
* MSMQ or SQL transport with distributed transactions (DTC) **disabled**.

**and** you are using timeouts or deferred messages (e.g. `Bus.Defer(...)`)

## Symptoms

When experiencing connectivity issues with the transport there's a chance that a due timeout/deferred message is lost. Therefore the message will never arrive.

## What to do if you are affected

We highly recommend to update to the latest patch versions of your NServiceBus and optional persistence and transport packages. For more details see issue Particular/NServiceBus#2885.

Connects to Particular/NServiceBus#2885