### PR TITLE
handle ConcurrencyException on TryRemove

### DIFF
--- a/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
+++ b/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
@@ -147,9 +147,11 @@
     <Compile Include="Timeouts\FakeLegacyTimoutDataClrTypeConversionListener.cs" />
     <Compile Include="Timeouts\LegacyTimeoutData.cs" />
     <Compile Include="Timeouts\Should_not_skip_timeouts.cs" />
+    <Compile Include="Timeouts\When_adding_timeouts.cs" />
     <Compile Include="Timeouts\When_converting_old_timeout_to_new_timeout.cs" />
     <Compile Include="Timeouts\When_fetching_old_timeouts_from_storage.cs" />
     <Compile Include="Timeouts\When_fetching_timeouts_from_storage.cs" />
+    <Compile Include="Timeouts\When_removing_timeouts_from_storage.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NServiceBus.RavenDB.Tests/RavenDBPersistenceTestBase.cs
+++ b/src/NServiceBus.RavenDB.Tests/RavenDBPersistenceTestBase.cs
@@ -12,7 +12,7 @@
         [SetUp]
         public virtual void SetUp()
         {
-            store = NewDocumentStore();
+            store = DocumentStoreFactory(this);
         }
 
         [TearDown]
@@ -55,5 +55,6 @@
 
         List<IDocumentSession> sessions = new List<IDocumentSession>();
         protected IDocumentStore store;
+        protected Func<RavenTestBase, IDocumentStore> DocumentStoreFactory { get; set; } = t => t.NewDocumentStore();
     }
 }

--- a/src/NServiceBus.RavenDB.Tests/Timeouts/Should_not_skip_timeouts.cs
+++ b/src/NServiceBus.RavenDB.Tests/Timeouts/Should_not_skip_timeouts.cs
@@ -58,7 +58,7 @@
                             Time = DateTime.UtcNow.AddSeconds(RandomProvider.GetThreadRandom().Next(1, 20)),
                             OwningTimeoutManager = string.Empty
                         };
-                        persister.Add(td, context);
+                        persister.Add(td, context).Wait();
                         expected.Add(new Tuple<string, DateTime>(td.Id, td.Time));
                         lastTimeout = (td.Time > lastTimeout) ? td.Time : lastTimeout;
                     }
@@ -157,7 +157,7 @@
                             Time = DateTime.UtcNow.AddSeconds(RandomProvider.GetThreadRandom().Next(1, 20)),
                             OwningTimeoutManager = string.Empty
                         };
-                        persister.Add(td, context);
+                        persister.Add(td, context).Wait();
                         Interlocked.Increment(ref expected);
                         lastExpectedTimeout = (td.Time > lastExpectedTimeout) ? td.Time : lastExpectedTimeout;
                     }
@@ -185,7 +185,7 @@
                                 Time = DateTime.UtcNow.AddSeconds(RandomProvider.GetThreadRandom().Next(1, 20)),
                                 OwningTimeoutManager = string.Empty
                             };
-                            persister2.Add(td, context);
+                            persister2.Add(td, context).Wait();
                             Interlocked.Increment(ref expected);
                             lastExpectedTimeout = (td.Time > lastExpectedTimeout) ? td.Time : lastExpectedTimeout;
                         }

--- a/src/NServiceBus.RavenDB.Tests/Timeouts/When_adding_timeouts.cs
+++ b/src/NServiceBus.RavenDB.Tests/Timeouts/When_adding_timeouts.cs
@@ -1,0 +1,40 @@
+﻿namespace NServiceBus.RavenDB.Tests.Timeouts
+{
+    using System;
+    using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
+    using NServiceBus.TimeoutPersisters.RavenDB;
+    using NUnit.Framework;
+    using TimeoutData = NServiceBus.Timeout.Core.TimeoutData;
+
+    public class When_adding_timeouts : RavenDBPersistenceTestBase
+    {
+        [Test]
+        public async Task Add_WhenNoIdProvided_ShouldSetDbGeneratedTimeoutId()
+        {
+            var persister = new TimeoutPersister(store);
+            var timeout = new TimeoutData { Id = null };
+
+            await persister.Add(timeout, new ContextBag());
+            Assert.IsNotNull(timeout.Id);
+
+            var result = await persister.Peek(timeout.Id, new ContextBag());
+            Assert.IsNotNull(result);
+        }
+
+        [Test]
+        public async Task Add_WhenIdProvided_ShouldOverrideGivenId()
+        {
+            var persister = new TimeoutPersister(store);
+
+            var timeoutId = Guid.NewGuid().ToString();
+            var timeout = new TimeoutData { Id = timeoutId };
+
+            await persister.Add(timeout, new ContextBag());
+            Assert.AreNotEqual(timeoutId, timeout.Id);
+
+            var result = await persister.Peek(timeoutId, new ContextBag());
+            Assert.IsNull(result);
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB.Tests/Timeouts/When_removing_timeouts_from_storage.cs
+++ b/src/NServiceBus.RavenDB.Tests/Timeouts/When_removing_timeouts_from_storage.cs
@@ -1,0 +1,156 @@
+﻿namespace NServiceBus.RavenDB.Tests.Timeouts
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Transactions;
+    using NServiceBus.Extensibility;
+    using NServiceBus.TimeoutPersisters.RavenDB;
+    using NUnit.Framework;
+    using Raven.Abstractions.Exceptions;
+    using Raven.Client;
+    using TimeoutData = NServiceBus.Timeout.Core.TimeoutData;
+
+    public class When_removing_timeouts_from_storage : RavenDBPersistenceTestBase
+    {
+        public When_removing_timeouts_from_storage()
+        {
+            // in-memory store doesn't support dtc
+            DocumentStoreFactory = t => t.NewDocumentStore(false, "esent");
+        }
+
+        [Test]
+        public async Task Remove_WhenNoTimeoutRemoved_ShouldReturnFalse()
+        {
+            var persister = new TimeoutPersister(store);
+            await persister.Add(new TimeoutData(), new ContextBag());
+
+            var result = await persister.TryRemove(Guid.NewGuid().ToString(), new ContextBag());
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public async Task Remove_WhenTimeoutRemoved_ShouldReturnTrue()
+        {
+            var persister = new TimeoutPersister(store);
+            var timeoutData = new TimeoutData();
+            await persister.Add(timeoutData, new ContextBag());
+
+            var result = await persister.TryRemove(timeoutData.Id, new ContextBag());
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public async Task Remove_WhenConcurrentDeletesUsingDtc_OnlyOneOperationShouldSucceed()
+        {
+            var persister = new TimeoutPersister(store);
+            var timeoutData = new TimeoutData();
+            await persister.Add(timeoutData, new ContextBag());
+
+            var documentRemoved = new CountdownEvent(2);
+
+            var t1 = Task.Run(async () =>
+            {
+                using (var tx = new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+                {
+                    var result = await persister.TryRemove(timeoutData.Id, new ContextBag());
+                    documentRemoved.Signal(1);
+                    documentRemoved.Wait();
+                    tx.Complete();
+                    return result;
+                }
+            });
+
+            var t2 = Task.Run(async () =>
+            {
+                using (var tx = new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+                {
+                    var result = await persister.TryRemove(timeoutData.Id, new ContextBag());
+                    documentRemoved.Signal(1);
+                    documentRemoved.Wait();
+                    tx.Complete();
+                    return result;
+                }
+            });
+
+            Assert.IsTrue(t1.Result | t2.Result, "the document should be deleted");
+            Assert.IsFalse(t1.Result && t2.Result, "only one operation should complete successfully");
+        }
+
+        [Test]
+        public void Raven_WhenConcurrentDeletesWithDtc_ShouldThrowConcurrencyException()
+        {
+            // Raven does not throw ConcurrencyExceptions when concurrently deleting documents without using DTC.
+            // When using DTC we need to rely on Raven throwing this exception to avoid dispatching duplicate messages.
+            // See issue http://issues.hibernatingrhinos.com/issue/RavenDB-4000
+
+            var document = new DemoDocument();
+            using (var session = store.OpenSession())
+            {
+                session.Store(document);
+                session.SaveChanges();
+            }
+
+            var documentLoaded = new CountdownEvent(2);
+            var documentDeleted = new CountdownEvent(2);
+
+            var t1 = Task.Run(async () =>
+            {
+                using (var tx = new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+                {
+                    var result = await TryDeleteDocumentAsync(store, document.Id, documentLoaded, documentDeleted);
+                    tx.Complete();
+                    return result;
+                }
+            });
+
+            var t2 = Task.Run(async () =>
+            {
+                using (var tx = new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+                {
+                    var result = await TryDeleteDocumentAsync(store, document.Id, documentLoaded, documentDeleted);
+                    tx.Complete();
+                    return result;
+                }
+            });
+
+            Assert.IsTrue(t1.Result | t2.Result, "the document should be deleted");
+            Assert.IsFalse(t1.Result && t2.Result, "only one operation should complete successfully");
+        }
+
+        static async Task<bool> TryDeleteDocumentAsync(IDocumentStore store, Guid documentId, CountdownEvent documentLoaded,
+            CountdownEvent documentDeleted)
+        {
+            try
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    var document = await session.LoadAsync<DemoDocument>(documentId);
+
+                    documentLoaded.Signal(1);
+                    documentLoaded.Wait();
+
+                    session.Delete(document);
+
+                    documentDeleted.Signal(1);
+                    documentDeleted.Wait();
+
+                    await session.SaveChangesAsync();
+                    return true;
+                }
+            }
+            catch (ConcurrencyException e)
+            {
+                Console.WriteLine(e);
+                return false;
+            }
+        }
+
+        class DemoDocument
+        {
+            public Guid Id { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
return false when `TryRemove` cannot delete a timeout because of a concurrent operation