### PR TITLE
Relaxed version constraints between client and server

### DIFF
--- a/src/NServiceBus.RavenDB/ConfigureRavenPersistence.cs
+++ b/src/NServiceBus.RavenDB/ConfigureRavenPersistence.cs
@@ -397,12 +397,12 @@ Further instructions can be found at:http://particular.net/articles/using-ravend
                     return false;
                 }
 
-                return !string.IsNullOrEmpty(ProductVersion) && ProductVersion.StartsWith("2.5") && buildVersion >= 2908;
+                return !string.IsNullOrEmpty(ProductVersion) && buildVersion >= 2908;
             }
 
             public override string ToString()
             {
-                return string.Format("Product version: {0}, Build version: {1}", ProductVersion, BuildVersion);
+                return $"Product version: {ProductVersion}, Build version: {BuildVersion}";
             }
         }
     }


### PR DESCRIPTION
## Who's affected
* Any user trying to use NServiceBus.RavenDB with a newer server version greater than 3.0

## Symptoms 

When the RavenDB server is upgrade to 3.0 or higher and the host is started the following exception occurs:

```
System.InvalidOperationException: The RavenDB server you have specified is detected to be Product version: 3.0.0 / cdc39ac / , Build version: 3800. NServiceBus requires RavenDB version 2.5 build 2908 or higher to operate correctly. Please update your RavenDB server.
```

## Description
* Relaxed version constraints between client and server, fixes #117