### PR TITLE
Async support

### DIFF
--- a/src/NServiceBus.RavenDB.AcceptanceTests/NServiceBus.RavenDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/NServiceBus.RavenDB.AcceptanceTests.csproj
@@ -287,6 +287,8 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/NServiceBus.RavenDB.AcceptanceTests/When_using_a_sagafinder.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/When_using_a_sagafinder.cs
@@ -45,15 +45,15 @@
             {
                 public Context Context { get; set; }
 
-                public Task<SagaFinderSagaData> FindBy(StartSagaMessage message, ReadOnlyContextBag options)
+                public async Task<SagaFinderSagaData> FindBy(StartSagaMessage message, ReadOnlyContextBag options)
                 {
                     if (Context.SagaId == Guid.Empty)
                     {
-                        return Task.FromResult(default(SagaFinderSagaData));
+                        return await Task.FromResult(default(SagaFinderSagaData));
                     }
 
-                    var session = options.Get<IDocumentSession>();
-                    return Task.FromResult(session.Load<SagaFinderSagaData>(Context.SagaId));
+                    var session = options.Get<IAsyncDocumentSession>();
+                    return await session.LoadAsync<SagaFinderSagaData>(Context.SagaId).ConfigureAwait(false);
                 }
             }
 

--- a/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
+++ b/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
@@ -153,6 +153,8 @@
     <Compile Include="Timeouts\When_fetching_timeouts_from_storage.cs" />
     <Compile Include="Timeouts\When_removing_timeouts_from_storage.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/NServiceBus.RavenDB.Tests/Outbox/When_adding_outbox_messages.cs
+++ b/src/NServiceBus.RavenDB.Tests/Outbox/When_adding_outbox_messages.cs
@@ -9,6 +9,7 @@ namespace NServiceBus.RavenDB.Tests.Outbox
     using NServiceBus.RavenDB.Outbox;
     using NUnit.Framework;
     using Raven.Abstractions.Exceptions;
+    using Raven.Client;
     using Raven.Client.Exceptions;
 
     [TestFixture]
@@ -105,10 +106,10 @@ namespace NServiceBus.RavenDB.Tests.Outbox
 
             WaitForIndexing(store);
 
-            using (var s = store.OpenSession())
+            using (var s = store.OpenAsyncSession())
             {
-                var result = s.Query<OutboxRecord>()
-                    .SingleOrDefault(o => o.MessageId == id);
+                var result = await s.Query<OutboxRecord>()
+                    .SingleOrDefaultAsync(o => o.MessageId == id);
 
                 Assert.NotNull(result);
                 Assert.True(result.Dispatched);

--- a/src/NServiceBus.RavenDB.Tests/Outbox/When_cleaning_outbox_messages.cs
+++ b/src/NServiceBus.RavenDB.Tests/Outbox/When_cleaning_outbox_messages.cs
@@ -9,6 +9,7 @@
     using NServiceBus.Outbox;
     using NServiceBus.RavenDB.Outbox;
     using NUnit.Framework;
+    using Raven.Client;
 
     [TestFixture]
     public class When_cleaning_outbox_messages : RavenDBPersistenceTestBase
@@ -30,7 +31,7 @@
 
             var persister = new OutboxPersister(store);
 
-            using (var transaction = await persister.BeginTransaction(context))
+            using(var transaction = await persister.BeginTransaction(context))
             {
                 await persister.Store(new OutboxMessage("NotDispatched", new List<TransportOperation>()), transaction, context);
 
@@ -38,12 +39,12 @@
             }
 
             var outboxMessage = new OutboxMessage(id, new List<TransportOperation>
-            {
-                new TransportOperation(id, new Dictionary<string, string>(), new byte[1024*5], new Dictionary<string, string>())
-            });
+                {
+                    new TransportOperation(id, new Dictionary<string, string>(), new byte[1024*5], new Dictionary<string, string>())
+                });
 
 
-            using (var transaction = await persister.BeginTransaction(context))
+            using(var transaction = await persister.BeginTransaction(context))
             {
                 await persister.Store(outboxMessage, transaction, context);
                 await transaction.Commit();
@@ -53,17 +54,18 @@
             await persister.SetAsDispatched(id, context);
             Thread.Sleep(TimeSpan.FromSeconds(1)); //Need to wait for dispatch logic to finish
 
+            WaitForUserToContinueTheTest(store);
             WaitForIndexing(store);
 
             var cleaner = new OutboxRecordsCleaner
             {
                 DocumentStore = store
             };
-            cleaner.RemoveEntriesOlderThan(DateTime.UtcNow.AddMinutes(1));
+            await cleaner.RemoveEntriesOlderThan(DateTime.UtcNow.AddMinutes(1));
 
-            using (var s = store.OpenSession())
+            using(var s = store.OpenAsyncSession())
             {
-                var result = s.Query<OutboxRecord>().ToList();
+                var result = await s.Query<OutboxRecord>().ToListAsync();
 
                 Assert.AreEqual(1, result.Count);
                 Assert.AreEqual("NotDispatched", result[0].MessageId);

--- a/src/NServiceBus.RavenDB.Tests/Persistence/DocumentStoreExtensionsForVoron.cs
+++ b/src/NServiceBus.RavenDB.Tests/Persistence/DocumentStoreExtensionsForVoron.cs
@@ -2,6 +2,8 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
+    using Raven.Abstractions.Connection;
     using Raven.Abstractions.Data;
     using Raven.Client.Document;
 
@@ -10,32 +12,36 @@
         public static IDisposable SetupVoronTest(this DocumentStore store)
         {
             store.Initialize();
-            var dataDir = $"~/VoronTest-{Guid.NewGuid().ToString("N").Substring(0, 10).ToUpper()}";
+            var dbName = $"VoronTest-{Guid.NewGuid().ToString("N").Substring(0, 10).ToUpper()}";
+            var dataDir = "~/" + dbName;
             store.DatabaseCommands.GlobalAdmin.CreateDatabase(new DatabaseDocument
             {
-                Id = "VoronTest",
+                Id = dbName,
                 Settings = new Dictionary<string, string>
                     {
                         { "Raven/StorageTypeName", "voron" },
                         { "Raven/DataDir", dataDir }
                     }
             });
-            store.DefaultDatabase = "VoronTest";
-            return new VoronTestDeleter(store);
+            store.DefaultDatabase = dbName;
+            store.DatabaseCommands.GlobalAdmin.EnsureDatabaseExists(dbName);
+            return new VoronTestDeleter(store, dbName);
         }
 
         class VoronTestDeleter : IDisposable
         {
             readonly DocumentStore store;
+            readonly string dbName;
 
-            public VoronTestDeleter(DocumentStore store)
+            public VoronTestDeleter(DocumentStore store, string dbName)
             {
                 this.store = store;
+                this.dbName = dbName;
             }
 
             public void Dispose()
             {
-                store.DatabaseCommands.GlobalAdmin.DeleteDatabase("VoronTest", hardDelete: true);
+                store.DatabaseCommands.GlobalAdmin.DeleteDatabase(dbName, hardDelete: true);
             }
         }
     }

--- a/src/NServiceBus.RavenDB.Tests/Persistence/TestConnectionVerifier.cs
+++ b/src/NServiceBus.RavenDB.Tests/Persistence/TestConnectionVerifier.cs
@@ -69,6 +69,8 @@
                 documentStore.Initialize();
 
                 ConnectionVerifier.VerifyConnectionToRavenDBServer(documentStore);
+
+                documentStore.DatabaseCommands.GlobalAdmin.DeleteDatabase("Test", hardDelete: true);
             }
         }
     }

--- a/src/NServiceBus.RavenDB.Tests/RavenDBPersistenceTestBase.cs
+++ b/src/NServiceBus.RavenDB.Tests/RavenDBPersistenceTestBase.cs
@@ -23,9 +23,9 @@
             store.Dispose();
         }
 
-        protected internal IDocumentSession OpenSession()
+        protected internal IAsyncDocumentSession OpenAsyncSession()
         {
-            var documentSession = store.OpenSession();
+            var documentSession = store.OpenAsyncSession();
             documentSession.Advanced.AllowNonAuthoritativeInformation = false;
             documentSession.Advanced.UseOptimisticConcurrency = true;
             sessions.Add(documentSession);
@@ -53,7 +53,7 @@
             }
         }
 
-        List<IDocumentSession> sessions = new List<IDocumentSession>();
+        List<IAsyncDocumentSession> sessions = new List<IAsyncDocumentSession>();
         protected IDocumentStore store;
         protected Func<RavenTestBase, IDocumentStore> DocumentStoreFactory { get; set; } = t => t.NewDocumentStore();
     }

--- a/src/NServiceBus.RavenDB.Tests/RavenSessionFactory.cs
+++ b/src/NServiceBus.RavenDB.Tests/RavenSessionFactory.cs
@@ -3,22 +3,22 @@
     using NServiceBus.RavenDB.Persistence;
     using Raven.Client;
 
-    class RavenSessionFactory : ISessionProvider
+    class RavenAsyncSessionFactory : IAsyncSessionProvider
     {
-        IDocumentSession session;
+        IAsyncDocumentSession session;
         readonly IDocumentStore store;
 
-        public RavenSessionFactory(IDocumentStore store)
+        public RavenAsyncSessionFactory(IDocumentStore store)
         {
             session = null;
             this.store = store;
         }
 
-        public IDocumentSession Session => session ?? (session = OpenSession());
+        public IAsyncDocumentSession AsyncSession => session ?? (session = OpenAsyncSession());
 
-        IDocumentSession OpenSession()
+        IAsyncDocumentSession OpenAsyncSession()
         {
-            var documentSession = store.OpenSession();
+            var documentSession = store.OpenAsyncSession();
             documentSession.Advanced.AllowNonAuthoritativeInformation = false;
             documentSession.Advanced.UseOptimisticConcurrency = true;
             return documentSession;
@@ -35,7 +35,10 @@
 
         public void SaveChanges()
         {
-            session?.SaveChanges();
+            session?.SaveChangesAsync()
+                .ConfigureAwait(false)
+                .GetAwaiter()
+                .GetResult();
         }
     }
 }

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/RavenTestBaseForSagaPersistenceOptions.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/RavenTestBaseForSagaPersistenceOptions.cs
@@ -4,10 +4,10 @@ using Raven.Client;
 
 public static class RavenTestBaseForSagaPersistenceOptions
 {
-    public static ContextBag CreateContextWithSessionPresent(this RavenDBPersistenceTestBase testBase, out IDocumentSession session)
+    public static ContextBag CreateContextWithAsyncSessionPresent(this RavenDBPersistenceTestBase testBase, out IAsyncDocumentSession session)
     {
         var context = new ContextBag();
-        session = testBase.OpenSession();
+        session = testBase.OpenAsyncSession();
         context.Set(session);
         return context;
     }

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/Saga_with_unique_property_set_to_null.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/Saga_with_unique_property_set_to_null.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.RavenDB.Tests;
 using NServiceBus.SagaPersisters.RavenDB;
@@ -9,7 +10,7 @@ using Raven.Client;
 public class Saga_with_unique_property_set_to_null : RavenDBPersistenceTestBase
 {
     [Test]
-    public void should_throw_a_ArgumentNullException()
+    public async Task should_throw_a_ArgumentNullException()
     {
         var saga1 = new SagaData
         {
@@ -17,15 +18,16 @@ public class Saga_with_unique_property_set_to_null : RavenDBPersistenceTestBase
             UniqueString = null
         };
 
-        IDocumentSession session;
-        var context = this.CreateContextWithSessionPresent(out session);
+        IAsyncDocumentSession session;
+        var context = this.CreateContextWithAsyncSessionPresent(out session);
         var persister = new SagaPersister();
 
-        Assert.Throws<ArgumentNullException>(() =>
+        var exception = await Catch<ArgumentNullException>(async () =>
         {
-            persister.Save(saga1, this.CreateMetadata<SomeSaga>(saga1), context);
-            session.SaveChanges();
+            await persister.Save(saga1, this.CreateMetadata<SomeSaga>(saga1), context);
+            await session.SaveChangesAsync().ConfigureAwait(false);
         });
+        Assert.IsNotNull(exception);
     }
 
     class SomeSaga : Saga<SagaData>

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_completing_a_saga_with_unique_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_completing_a_saga_with_unique_property.cs
@@ -16,8 +16,8 @@ public class When_completing_a_saga_with_unique_property : RavenDBPersistenceTes
     {
         var sagaId = Guid.NewGuid();
 
-        IDocumentSession session;
-        var options = this.CreateContextWithSessionPresent(out session);
+        IAsyncDocumentSession session;
+        var options = this.CreateContextWithAsyncSessionPresent(out session);
         var persister = new SagaPersister();
         var entity = new SagaData
         {
@@ -25,14 +25,14 @@ public class When_completing_a_saga_with_unique_property : RavenDBPersistenceTes
         };
 
         await persister.Save(entity, this.CreateMetadata<SomeSaga>(entity), options);
-        session.SaveChanges();
+        await session.SaveChangesAsync().ConfigureAwait(false);
 
         var saga = await persister.Get<SagaData>(sagaId, options);
         await persister.Complete(saga, options);
-        session.SaveChanges();
+        await session.SaveChangesAsync().ConfigureAwait(false);
 
         Assert.Null(await persister.Get<SagaData>(sagaId, options));
-        Assert.Null(session.Query<SagaUniqueIdentity>().Customize(c => c.WaitForNonStaleResults()).SingleOrDefault(u => u.SagaId == sagaId));
+        Assert.Null(await session.Query<SagaUniqueIdentity>().Customize(c => c.WaitForNonStaleResults()).SingleOrDefaultAsync(u => u.SagaId == sagaId).ConfigureAwait(false));
     }
 
 

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_completing_a_version3_saga.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_completing_a_version3_saga.cs
@@ -36,7 +36,7 @@ public class When_completing_a_version3_saga : RavenDBPersistenceTestBase
         await persister.Complete(saga, options);
         await session.SaveChangesAsync().ConfigureAwait(false);
 
-        Assert.Null(session.Query<SagaUniqueIdentity>().Customize(c => c.WaitForNonStaleResults()).SingleOrDefault(u => u.SagaId == sagaId));
+        Assert.Null(await session.Query<SagaUniqueIdentity>().Customize(c => c.WaitForNonStaleResults()).SingleOrDefaultAsync(u => u.SagaId == sagaId));
     }
 
 

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_completing_a_version3_saga.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_completing_a_version3_saga.cs
@@ -16,8 +16,8 @@ public class When_completing_a_version3_saga : RavenDBPersistenceTestBase
     {
         var sagaId = Guid.NewGuid();
 
-        IDocumentSession session;
-        var options = this.CreateContextWithSessionPresent(out session);
+        IAsyncDocumentSession session;
+        var options = this.CreateContextWithAsyncSessionPresent(out session);
         var persister = new SagaPersister();
 
         var sagaEntity = new SagaData
@@ -29,12 +29,12 @@ public class When_completing_a_version3_saga : RavenDBPersistenceTestBase
         await persister.Save(sagaEntity, this.CreateMetadata<SomeSaga>(sagaEntity), options);
 
         session.Advanced.GetMetadataFor(sagaEntity).Remove("NServiceBus-UniqueDocId");
-        session.SaveChanges();
+        await session.SaveChangesAsync().ConfigureAwait(false);
 
 
         var saga = await persister.Get<SagaData>(sagaId, options);
         await persister.Complete(saga, options);
-        session.SaveChanges();
+        await session.SaveChangesAsync().ConfigureAwait(false);
 
         Assert.Null(session.Query<SagaUniqueIdentity>().Customize(c => c.WaitForNonStaleResults()).SingleOrDefault(u => u.SagaId == sagaId));
     }

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_a_concrete_class_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_a_concrete_class_property.cs
@@ -21,11 +21,11 @@ public class When_persisting_a_saga_entity_with_a_concrete_class_property : Rave
             }
         };
 
-        IDocumentSession session;
-        var options = this.CreateContextWithSessionPresent(out session);
+        IAsyncDocumentSession session;
+        var options = this.CreateContextWithAsyncSessionPresent(out session);
         var persister = new SagaPersister();
         await persister.Save(entity, this.CreateMetadata<SomeSaga>(entity), options);
-        session.SaveChanges();
+        await session.SaveChangesAsync().ConfigureAwait(false);
         var savedEntity = await persister.Get<SagaData>(entity.Id, options);
         Assert.AreEqual(entity.TestComponent.Property, savedEntity.TestComponent.Property);
         Assert.AreEqual(entity.TestComponent.AnotherProperty, savedEntity.TestComponent.AnotherProperty);

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_a_date_time_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_a_date_time_property.cs
@@ -17,11 +17,11 @@ public class When_persisting_a_saga_entity_with_a_DateTime_property : RavenDBPer
             Id = Guid.NewGuid(),
             DateTimeProperty = DateTime.Parse("12/02/2010 12:00:00.01")
         };
-        IDocumentSession session;
-        var options = this.CreateContextWithSessionPresent(out session);
+        IAsyncDocumentSession session;
+        var options = this.CreateContextWithAsyncSessionPresent(out session);
         var persister = new SagaPersister();
         await persister.Save(entity, this.CreateMetadata<SomeSaga>(entity), options);
-        session.SaveChanges();
+        await session.SaveChangesAsync().ConfigureAwait(false);
         var savedEntity = await persister.Get<SagaData>(entity.Id, options);
         Assert.AreEqual(entity.DateTimeProperty, savedEntity.DateTimeProperty);
     }

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_an_Enum_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_an_Enum_property.cs
@@ -18,12 +18,12 @@ public class When_persisting_a_saga_entity_with_an_Enum_property : RavenDBPersis
             Status = StatusEnum.AnotherStatus
         };
 
-        IDocumentSession session;
+        IAsyncDocumentSession session;
 
-        var context = this.CreateContextWithSessionPresent(out session);
+        var context = this.CreateContextWithAsyncSessionPresent(out session);
         var persister = new SagaPersister();
         await persister.Save(entity, this.CreateMetadata<SomeSaga>(entity), context);
-        session.SaveChanges();
+        await session.SaveChangesAsync().ConfigureAwait(false);
 
         var savedEntity = await persister.Get<SagaData>(entity.Id, context);
         Assert.AreEqual(entity.Status, savedEntity.Status);

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_inherited_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_inherited_property.cs
@@ -12,8 +12,8 @@ public class When_persisting_a_saga_entity_with_inherited_property : RavenDBPers
     [Test]
     public async Task Inherited_property_classes_should_be_persisted()
     {
-        IDocumentSession session;
-        var options = this.CreateContextWithSessionPresent(out session);
+        IAsyncDocumentSession session;
+        var options = this.CreateContextWithAsyncSessionPresent(out session);
         var persister = new SagaPersister();
         var entity = new SagaData
         {
@@ -24,7 +24,7 @@ public class When_persisting_a_saga_entity_with_inherited_property : RavenDBPers
             }
         };
         await persister.Save(entity, this.CreateMetadata<SomeSaga>(entity), options);
-        session.SaveChanges();
+        await session.SaveChangesAsync().ConfigureAwait(false);
 
         var savedEntity = await persister.Get<SagaData>(entity.Id, options);
         var expected = (PolymorphicProperty) entity.PolymorphicRelatedProperty;

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga.cs
@@ -12,8 +12,8 @@ public class When_persisting_a_saga_with_the_same_unique_property_as_a_completed
     [Test]
     public async Task It_should_persist_successfully()
     {
-        IDocumentSession session;
-        var options = this.CreateContextWithSessionPresent(out session);
+        IAsyncDocumentSession session;
+        var options = this.CreateContextWithAsyncSessionPresent(out session);
         var persister = new SagaPersister();
         var uniqueString = Guid.NewGuid().ToString();
         var saga1 = new SagaData
@@ -22,16 +22,16 @@ public class When_persisting_a_saga_with_the_same_unique_property_as_a_completed
             UniqueString = uniqueString
         };
         await persister.Save(saga1, this.CreateMetadata<SomeSaga>(saga1), options);
-        session.SaveChanges();
+        await session.SaveChangesAsync().ConfigureAwait(false);
         session.Dispose();
 
-        options = this.CreateContextWithSessionPresent(out session);
+        options = this.CreateContextWithAsyncSessionPresent(out session);
         var saga = await persister.Get<SagaData>(saga1.Id, options);
         await persister.Complete(saga, options);
-        session.SaveChanges();
+        await session.SaveChangesAsync().ConfigureAwait(false);
         session.Dispose();
 
-        options = this.CreateContextWithSessionPresent(out session);
+        options = this.CreateContextWithAsyncSessionPresent(out session);
         var saga2 = new SagaData
         {
             Id = Guid.NewGuid(),
@@ -39,7 +39,7 @@ public class When_persisting_a_saga_with_the_same_unique_property_as_a_completed
         };
 
         await persister.Save(saga2, this.CreateMetadata<SomeSaga>(saga2), options);
-        session.SaveChanges();
+        await session.SaveChangesAsync().ConfigureAwait(false);
     }
 
     class SomeSaga : Saga<SagaData>

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_storing_a_saga_with_a_long_namespace.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_storing_a_saga_with_a_long_namespace.cs
@@ -12,8 +12,8 @@ public class When_storing_a_saga_with_a_long_namespace : RavenDBPersistenceTestB
     [Test]
     public async Task Should_not_generate_a_to_long_unique_property_id()
     {
-        IDocumentSession session;
-        var options = this.CreateContextWithSessionPresent(out session);
+        IAsyncDocumentSession session;
+        var options = this.CreateContextWithAsyncSessionPresent(out session);
         var persister = new SagaPersister();
         var uniqueString = Guid.NewGuid().ToString();
         var saga = new SagaWithUniquePropertyAndALongNamespace
@@ -22,7 +22,7 @@ public class When_storing_a_saga_with_a_long_namespace : RavenDBPersistenceTestB
                 UniqueString = uniqueString
             };
         await persister.Save(saga, this.CreateMetadata<SomeSaga>(saga), options);
-        session.SaveChanges();
+        await session.SaveChangesAsync().ConfigureAwait(false);
     }
 
     class SomeSaga : Saga<SagaWithUniquePropertyAndALongNamespace>

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_trying_to_fetch_a_non_existing_saga_by_its_unique_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_trying_to_fetch_a_non_existing_saga_by_its_unique_property.cs
@@ -12,8 +12,8 @@ public class When_trying_to_fetch_a_non_existing_saga_by_its_unique_property : R
     [Test]
     public async Task It_should_return_null()
     {
-        IDocumentSession session;
-        var options = this.CreateContextWithSessionPresent(out session);
+        IAsyncDocumentSession session;
+        var options = this.CreateContextWithAsyncSessionPresent(out session);
         var persister = new SagaPersister();
         Assert.Null(await persister.Get<SagaData>("UniqueString", Guid.NewGuid().ToString(), options));
     }

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_updating_a_saga_property_that_does_not_have_a_unique_attribute.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_updating_a_saga_property_that_does_not_have_a_unique_attribute.cs
@@ -12,8 +12,8 @@ public class When_updating_a_saga_property_that_does_not_have_a_unique_attribute
     [Test]
     public async Task It_should_persist_successfully()
     {
-        IDocumentSession session;
-        var options = this.CreateContextWithSessionPresent(out session);
+        IAsyncDocumentSession session;
+        var options = this.CreateContextWithAsyncSessionPresent(out session);
         var persister = new SagaPersister();
         var uniqueString = Guid.NewGuid().ToString();
 
@@ -25,12 +25,12 @@ public class When_updating_a_saga_property_that_does_not_have_a_unique_attribute
         };
 
         await persister.Save(saga1, this.CreateMetadata<SomeSaga>(saga1), options);
-        session.SaveChanges();
+        await session.SaveChangesAsync().ConfigureAwait(false);
 
         var saga = await persister.Get<SagaData>(saga1.Id, options);
         saga.NonUniqueString = "notUnique2";
         await persister.Update(saga, options);
-        session.SaveChanges();
+        await session.SaveChangesAsync().ConfigureAwait(false);
     }
 
     class SomeSaga : Saga<SagaData>

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_updating_a_saga_property_that_has_a_unique_attribute.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_updating_a_saga_property_that_has_a_unique_attribute.cs
@@ -12,8 +12,8 @@ public class When_updating_a_saga_property_that_has_a_unique_attribute : RavenDB
     [Test]
     public async Task It_should_allow_the_update()
     {
-        IDocumentSession session;
-        var options = this.CreateContextWithSessionPresent(out session);
+        IAsyncDocumentSession session;
+        var options = this.CreateContextWithAsyncSessionPresent(out session);
         var persister = new SagaPersister();
         var uniqueString = Guid.NewGuid().ToString();
         var saga1 = new SagaData
@@ -23,14 +23,14 @@ public class When_updating_a_saga_property_that_has_a_unique_attribute : RavenDB
         };
 
         await persister.Save(saga1, this.CreateMetadata<SomeSaga>(saga1), options);
-        session.SaveChanges();
+        await session.SaveChangesAsync().ConfigureAwait(false);
         session.Dispose();
 
-        options = this.CreateContextWithSessionPresent(out session);
+        options = this.CreateContextWithAsyncSessionPresent(out session);
         var saga = await persister.Get<SagaData>(saga1.Id, options);
         saga.UniqueString = Guid.NewGuid().ToString();
         await persister.Update(saga, options);
-        session.SaveChanges();
+        await session.SaveChangesAsync().ConfigureAwait(false);
         session.Dispose();
 
         var saga2 = new SagaData
@@ -40,9 +40,9 @@ public class When_updating_a_saga_property_that_has_a_unique_attribute : RavenDB
         };
 
         //this should not blow since we changed the unique value in the previous saga
-        options = this.CreateContextWithSessionPresent(out session);
+        options = this.CreateContextWithAsyncSessionPresent(out session);
         await persister.Save(saga2, this.CreateMetadata<SomeSaga>(saga2), options);
-        session.SaveChanges();
+        await session.SaveChangesAsync().ConfigureAwait(false);
     }
 
     class SomeSaga : Saga<SagaData>

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_updating_a_saga_without_unique_properties.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_updating_a_saga_without_unique_properties.cs
@@ -12,8 +12,8 @@ public class When_updating_a_saga_without_unique_properties : RavenDBPersistence
     [Test]
     public async Task It_should_persist_successfully()
     {
-        IDocumentSession session;
-        var options = this.CreateContextWithSessionPresent(out session);
+        IAsyncDocumentSession session;
+        var options = this.CreateContextWithAsyncSessionPresent(out session);
         var persister = new SagaPersister();
         var uniqueString = Guid.NewGuid().ToString();
         var anotherUniqueString = Guid.NewGuid().ToString();
@@ -25,13 +25,13 @@ public class When_updating_a_saga_without_unique_properties : RavenDBPersistence
             NonUniqueString = "notUnique"
         };
         await persister.Save(saga1, this.CreateMetadata<SomeSaga>(saga1), options);
-        session.SaveChanges();
+        await session.SaveChangesAsync().ConfigureAwait(false);
 
         var saga = await persister.Get<SagaData>(saga1.Id, options);
         saga.NonUniqueString = "notUnique2";
         saga.UniqueString = anotherUniqueString;
         await persister.Update(saga, options);
-        session.SaveChanges();
+        await session.SaveChangesAsync().ConfigureAwait(false);
     }
 
     class SomeSaga : Saga<SagaData>

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_converting_old_subscription_to_new_subscription.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_converting_old_subscription_to_new_subscription.cs
@@ -30,9 +30,9 @@
         [Test]
         public async Task Should_allow_old_subscriptions()
         {
-            var session = store.OpenSession();
+            var session = store.OpenAsyncSession();
             var messageType = MessageTypes.MessageA.Single();
-            session.Store(new OldSubscription
+            await session.StoreAsync(new OldSubscription
             {
                 Clients = new List<LegacyAddress>
                 {
@@ -40,8 +40,9 @@
                     new LegacyAddress("mytestendpoint", RuntimeEnvironment.MachineName)
                 },
                 MessageType = messageType
-            }, Subscription.FormatId(messageType));
-            session.SaveChanges();
+            }, Subscription.FormatId(messageType))
+            .ConfigureAwait(false);
+            await session.SaveChangesAsync().ConfigureAwait(false);
 
             List<string> subscriptions = null;
 
@@ -54,9 +55,9 @@
         [Test]
         public async Task Should_allow_old_subscriptions_without_machine_name()
         {
-            var session = store.OpenSession();
+            var session = store.OpenAsyncSession();
             var messageType = MessageTypes.MessageA.Single();
-            session.Store(new OldSubscription
+            await session.StoreAsync(new OldSubscription
             {
                 Clients = new List<LegacyAddress>
                 {
@@ -64,8 +65,8 @@
                     new LegacyAddress("mytestendpoint", null)
                 },
                 MessageType = messageType
-            }, Subscription.FormatId(messageType));
-            session.SaveChanges();
+            }, Subscription.FormatId(messageType)).ConfigureAwait(false);
+            await session.SaveChangesAsync().ConfigureAwait(false);
 
             List<string> subscriptions = null;
             var exception = await Catch(async () => { subscriptions = (await persister.GetSubscriberAddressesForMessage(MessageTypes.MessageA, new ContextBag())).ToList(); });
@@ -77,14 +78,14 @@
         [Test]
         public async Task Should_allow_old_subscriptions_with_empty_clients()
         {
-            var session = store.OpenSession();
+            var session = store.OpenAsyncSession();
             var messageType = MessageTypes.MessageA.Single();
-            session.Store(new OldSubscription
+            await session.StoreAsync(new OldSubscription
             {
                 Clients = new List<LegacyAddress>(),
                 MessageType = messageType
-            }, Subscription.FormatId(messageType));
-            session.SaveChanges();
+            }, Subscription.FormatId(messageType)).ConfigureAwait(false);
+            await session.SaveChangesAsync().ConfigureAwait(false);
 
             List<string> subscriptions = null;
             var exception = await Catch(async () => { subscriptions = (await persister.GetSubscriberAddressesForMessage(MessageTypes.MessageA, new ContextBag())).ToList(); });
@@ -95,9 +96,9 @@
         [Test]
         public async Task Should_allow_new_subscriptions()
         {
-            var session = store.OpenSession();
+            var session = store.OpenAsyncSession();
             var messageType = MessageTypes.MessageA.Single();
-            session.Store(new Subscription
+            await session.StoreAsync(new Subscription
             {
                 Clients = new List<string>
                 {
@@ -105,8 +106,8 @@
                     "mytestendpoint" + "@" + RuntimeEnvironment.MachineName
                 },
                 MessageType = messageType
-            }, Subscription.FormatId(messageType));
-            session.SaveChanges();
+            }, Subscription.FormatId(messageType)).ConfigureAwait(false);
+            await session.SaveChangesAsync().ConfigureAwait(false);
 
             var exception = await Catch(async () => { (await persister.GetSubscriberAddressesForMessage(MessageTypes.MessageA, new ContextBag())).ToList(); });
             Assert.Null(exception);

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_a_subscription_message.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_a_subscription_message.cs
@@ -6,6 +6,7 @@ using NServiceBus.RavenDB.Tests;
 using NServiceBus.Unicast.Subscriptions;
 using NServiceBus.Unicast.Subscriptions.RavenDB;
 using NUnit.Framework;
+using Raven.Client;
 
 [TestFixture]
 public class When_receiving_a_subscription_message : RavenDBPersistenceTestBase
@@ -25,12 +26,12 @@ public class When_receiving_a_subscription_message : RavenDBPersistenceTestBase
 
         await storage.Subscribe(clientEndpoint, messageTypes, new ContextBag());
 
-        using (var session = store.OpenSession())
+        using (var session = store.OpenAsyncSession())
         {
-            var subscriptions = session
+            var subscriptions = await session
                 .Query<Subscription>()
                 .Customize(c => c.WaitForNonStaleResults())
-                .Count();
+                .CountAsync();
 
             Assert.AreEqual(2, subscriptions);
         }

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_duplicate_subscription_messages.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_duplicate_subscription_messages.cs
@@ -7,6 +7,7 @@ using NServiceBus.RavenDB.Tests;
 using NServiceBus.Unicast.Subscriptions;
 using NServiceBus.Unicast.Subscriptions.RavenDB;
 using NUnit.Framework;
+using Raven.Client;
 
 [TestFixture]
 public class When_receiving_duplicate_subscription_messages : RavenDBPersistenceTestBase
@@ -26,12 +27,12 @@ public class When_receiving_duplicate_subscription_messages : RavenDBPersistence
             new MessageType("SomeMessageType", "1.0.0.0")
         }, new ContextBag());
 
-        using (var session = store.OpenSession())
+        using (var session = store.OpenAsyncSession())
         {
-            var subscriptions = session
+            var subscriptions = await session
                 .Query<Subscription>()
                 .Customize(c => c.WaitForNonStaleResults())
-                .Count();
+                .CountAsync();
 
             Assert.AreEqual(1, subscriptions);
         }

--- a/src/NServiceBus.RavenDB.Tests/Timeouts/Should_not_skip_timeouts.cs
+++ b/src/NServiceBus.RavenDB.Tests/Timeouts/Should_not_skip_timeouts.cs
@@ -40,7 +40,7 @@
 
                 var startSlice = DateTime.UtcNow.AddYears(-10);
                 // avoid cleanup from running during the test by making it register as being run
-                Assert.AreEqual(0, query.GetCleanupChunk(startSlice).Count());
+                Assert.AreEqual(0, (await query.GetCleanupChunk(startSlice)).Count());
 
                 var expected = new List<Tuple<string, DateTime>>();
                 var lastTimeout = DateTime.UtcNow;
@@ -89,7 +89,7 @@
                 // we need to perform manual cleaup.
                 while (true)
                 {
-                    var chunkToCleanup = query.GetCleanupChunk(DateTime.UtcNow.AddDays(1)).ToArray();
+                    var chunkToCleanup = (await query.GetCleanupChunk(DateTime.UtcNow.AddDays(1))).ToArray();
                     if (chunkToCleanup.Length == 0)
                     {
                         break;
@@ -137,7 +137,7 @@
 
                 var startSlice = DateTime.UtcNow.AddYears(-10);
                 // avoid cleanup from running during the test by making it register as being run
-                Assert.AreEqual(0, query.GetCleanupChunk(startSlice).Count());
+                Assert.AreEqual(0, (await query.GetCleanupChunk(startSlice)).Count());
 
                 const int insertsPerThread = 1000;
                 var expected = 0;
@@ -217,7 +217,7 @@
                 // we need to perform manual cleaup.
                 while (true)
                 {
-                    var chunkToCleanup = query.GetCleanupChunk(DateTime.UtcNow.AddDays(1)).ToArray();
+                    var chunkToCleanup = (await query.GetCleanupChunk(DateTime.UtcNow.AddDays(1))).ToArray();
                     Console.WriteLine("Cleanup: got a chunk of size " + chunkToCleanup.Length);
                     if (chunkToCleanup.Length == 0)
                     {

--- a/src/NServiceBus.RavenDB.Tests/Timeouts/Should_not_skip_timeouts.cs
+++ b/src/NServiceBus.RavenDB.Tests/Timeouts/Should_not_skip_timeouts.cs
@@ -104,9 +104,9 @@
                     WaitForIndexing(documentStore);
                 }
 
-                using (var session = documentStore.OpenSession())
+                using (var session = documentStore.OpenAsyncSession())
                 {
-                    var results = session.Query<TimeoutData>().ToList();
+                    var results = await session.Query<TimeoutData>().ToListAsync();
                     Assert.AreEqual(0, results.Count);
                 }
 
@@ -233,9 +233,9 @@
                     WaitForIndexing(documentStore);
                 }
 
-                using (var session = documentStore.OpenSession())
+                using (var session = documentStore.OpenAsyncSession())
                 {
-                    var results = session.Query<TimeoutData>().ToList();
+                    var results = await session.Query<TimeoutData>().ToListAsync();
                     Assert.AreEqual(0, results.Count);
                 }
 

--- a/src/NServiceBus.RavenDB.Tests/Timeouts/When_converting_old_timeout_to_new_timeout.cs
+++ b/src/NServiceBus.RavenDB.Tests/Timeouts/When_converting_old_timeout_to_new_timeout.cs
@@ -50,9 +50,9 @@ namespace NServiceBus.RavenDB.Tests.Timeouts
             };
             var context = new ContextBag();
 
-            var session = store.OpenSession();
-            session.Store(timeout);
-            session.SaveChanges();
+            var session = store.OpenAsyncSession();
+            await session.StoreAsync(timeout);
+            await session.SaveChangesAsync();
 
             Assert.True(await persister.TryRemove(timeout.Id, context));
         }
@@ -84,9 +84,9 @@ namespace NServiceBus.RavenDB.Tests.Timeouts
             };
             var context = new ContextBag();
 
-            var session = store.OpenSession();
-            session.Store(timeout);
-            session.SaveChanges();
+            var session = store.OpenAsyncSession();
+            await session.StoreAsync(timeout);
+            await session.SaveChangesAsync();
 
             Assert.True(await persister.TryRemove(timeout.Id, context));
         }

--- a/src/NServiceBus.RavenDB.Tests/Timeouts/When_fetching_old_timeouts_from_storage.cs
+++ b/src/NServiceBus.RavenDB.Tests/Timeouts/When_fetching_old_timeouts_from_storage.cs
@@ -32,10 +32,10 @@
         {
             const int numberOfTimeoutsToAdd = 10;
 
-            var session = store.OpenSession();
+            var session = store.OpenAsyncSession();
             for (var i = 0; i < numberOfTimeoutsToAdd; i++)
             {
-                session.Store(new LegacyTimeoutData
+                await session.StoreAsync(new LegacyTimeoutData
                 {
                     Time = DateTime.UtcNow.AddHours(-1),
                     Destination = new LegacyAddress("timeouts", RuntimeEnvironment.MachineName),
@@ -45,7 +45,7 @@
                     OwningTimeoutManager = "MyTestEndpoint",
                 });
             }
-            session.SaveChanges();
+            await session.SaveChangesAsync();
 
             WaitForIndexing(store);
 
@@ -57,12 +57,12 @@
         {
             const int numberOfTimeoutsToAdd = 10;
 
-            var session = store.OpenSession();
+            var session = store.OpenAsyncSession();
             for (var i = 0; i < numberOfTimeoutsToAdd; i++)
             {
                 if (i % 2 == 0)
                 {
-                    session.Store(new LegacyTimeoutData
+                    await session.StoreAsync(new LegacyTimeoutData
                     {
                         Time = DateTime.UtcNow.AddHours(-1),
                         Destination = new LegacyAddress("timeouts", RuntimeEnvironment.MachineName),
@@ -84,7 +84,7 @@
                 }
                 else
                 {
-                    session.Store(new TimeoutData
+                    await session.StoreAsync(new TimeoutData
                     {
                         Time = DateTime.UtcNow.AddHours(-1),
                         Destination = "timeouts" + "@" + RuntimeEnvironment.MachineName,
@@ -95,7 +95,7 @@
                     });
                 }
             }
-            session.SaveChanges();
+            await session.SaveChangesAsync();
 
             WaitForIndexing(store);
 
@@ -110,8 +110,8 @@
 
             var nextTime = DateTime.UtcNow.AddHours(1);
 
-            var session = store.OpenSession();
-            session.Store(new LegacyTimeoutData
+            var session = store.OpenAsyncSession();
+            await session.StoreAsync(new LegacyTimeoutData
             {
                 Time = nextTime,
                 Destination = new LegacyAddress("timeouts", RuntimeEnvironment.MachineName),
@@ -120,7 +120,7 @@
                 Headers = new Dictionary<string, string> { { "Bar", "34234" }, { "Foo", "aString1" }, { "Super", "aString2" } },
                 OwningTimeoutManager = "MyTestEndpoint",
             });
-            session.SaveChanges();
+            await session.SaveChangesAsync();
 
             WaitForIndexing(store);
 

--- a/src/NServiceBus.RavenDB.Tests/Timeouts/When_removing_timeouts_from_storage.cs
+++ b/src/NServiceBus.RavenDB.Tests/Timeouts/When_removing_timeouts_from_storage.cs
@@ -80,17 +80,17 @@
         }
 
         [Test]
-        public void Raven_WhenConcurrentDeletesWithDtc_ShouldThrowConcurrencyException()
+        public async Task Raven_WhenConcurrentDeletesWithDtc_ShouldThrowConcurrencyException()
         {
             // Raven does not throw ConcurrencyExceptions when concurrently deleting documents without using DTC.
             // When using DTC we need to rely on Raven throwing this exception to avoid dispatching duplicate messages.
             // See issue http://issues.hibernatingrhinos.com/issue/RavenDB-4000
 
             var document = new DemoDocument();
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                session.Store(document);
-                session.SaveChanges();
+                await session.StoreAsync(document);
+                await session.SaveChangesAsync();
             }
 
             var documentLoaded = new CountdownEvent(2);

--- a/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
+++ b/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
@@ -95,12 +95,13 @@
     <Compile Include="RavenDbSettingsExtensions.cs" />
     <Compile Include="SagaPersister\RavenDbSagaSettingsExtensions.cs" />
     <Compile Include="SessionManagement\ISessionProvider.cs" />
+    <Compile Include="SessionManagement\IAsyncSessionProvider.cs" />
     <Compile Include="Gateway\RavenDeduplication.cs" />
     <Compile Include="Internal\NoOpLogManager.cs" />
     <Compile Include="Internal\SharedDocumentStore.cs" />
     <Compile Include="RavenDBPersistence.cs" />
-    <Compile Include="SessionManagement\ProvidedSessionBehavior.cs" />
-    <Compile Include="SessionManagement\OpenSessionBehavior.cs" />
+    <Compile Include="SessionManagement\ProvidedAsyncSessionBehavior.cs" />
+    <Compile Include="SessionManagement\OpenAsyncSessionBehavior.cs" />
     <Compile Include="SessionManagement\RavenDbStorageSession.cs" />
     <Compile Include="SagaPersister\RavenDbSagaStorage.cs" />
     <Compile Include="SagaPersister\SagaPersister.cs" />

--- a/src/NServiceBus.RavenDB/Outbox/RavenDBOutboxTransaction.cs
+++ b/src/NServiceBus.RavenDB/Outbox/RavenDBOutboxTransaction.cs
@@ -6,24 +6,22 @@
 
     class RavenDBOutboxTransaction : OutboxTransaction
     {
-        public RavenDBOutboxTransaction(IDocumentSession session)
+        public RavenDBOutboxTransaction(IAsyncDocumentSession session)
         {
-            Session = session;
+            AsyncSession = session;
         }
 
         public void Dispose()
         {
-            Session.Dispose();
-            Session = null;
+            AsyncSession.Dispose();
+            AsyncSession = null;
         }
 
-        public Task Commit()
+        public async Task Commit()
         {
-            Session.SaveChanges();
-
-            return Task.FromResult(0);
+            await AsyncSession.SaveChangesAsync().ConfigureAwait(false);
         }
 
-        public IDocumentSession Session { get; private set; }
+        public IAsyncDocumentSession AsyncSession { get; private set; }
     }
 }

--- a/src/NServiceBus.RavenDB/Outbox/RavenDbOutboxStorage.cs
+++ b/src/NServiceBus.RavenDB/Outbox/RavenDbOutboxStorage.cs
@@ -73,7 +73,9 @@
 
             void PerformCleanup(object state)
             {
-                Cleaner.RemoveEntriesOlderThan(DateTime.UtcNow - timeToKeepDeduplicationData);
+                Cleaner.RemoveEntriesOlderThan(DateTime.UtcNow - timeToKeepDeduplicationData)
+                    .GetAwaiter()
+                    .GetResult();
             }
 
             Timer cleanupTimer;

--- a/src/NServiceBus.RavenDB/RavenDbSettingsExtensions.cs
+++ b/src/NServiceBus.RavenDB/RavenDbSettingsExtensions.cs
@@ -15,7 +15,7 @@
     {
         internal const string DocumentStoreSettingsKey = "RavenDbDocumentStore";
         internal const string DefaultConnectionParameters = "RavenDbConnectionParameters";
-        internal const string SharedSessionSettingsKey = "RavenDbSharedSession";
+        internal const string SharedAsyncSessionSettingsKey = "RavenDbSharedAsyncSession";
 
         /// <summary>
         ///     Configures the storages to use the given document store supplied
@@ -49,9 +49,22 @@
         /// <param name="cfg"></param>
         /// <param name="getSessionFunc">A func returning the session to be used</param>
         /// <returns></returns>
+        [ObsoleteEx( Message = "Use the 'UseSharedAsyncSession' configuration extension method to provide an async session.", RemoveInVersion = "5", TreatAsErrorFromVersion = "4" )]
         public static PersistenceExtentions<RavenDBPersistence> UseSharedSession(this PersistenceExtentions<RavenDBPersistence> cfg, Func<IDocumentSession> getSessionFunc)
         {
-            cfg.GetSettings().Set(SharedSessionSettingsKey, getSessionFunc);
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        ///     Specifies the async session that the shared persisters (saga + outbox) that should be used. The lifecycle is controled by
+        ///     me
+        /// </summary>
+        /// <param name="cfg"></param>
+        /// <param name="getAsyncSessionFunc">A func returning the async session to be used</param>
+        /// <returns></returns>
+        public static PersistenceExtentions<RavenDBPersistence> UseSharedAsyncSession( this PersistenceExtentions<RavenDBPersistence> cfg, Func<IAsyncDocumentSession> getAsyncSessionFunc )
+        {
+            cfg.GetSettings().Set( SharedAsyncSessionSettingsKey, getAsyncSessionFunc );
             return cfg;
         }
 
@@ -67,7 +80,7 @@
      //todo: obsolete
         public static PersistenceExtentions<RavenDBPersistence> SetMessageToDatabaseMappingConvention(this PersistenceExtentions<RavenDBPersistence> cfg, Func<IDictionary<string,string>, string> convention)
         {
-            OpenSessionBehavior.GetDatabaseName = convention;
+            OpenAsyncSessionBehavior.GetDatabaseName = convention;
             return cfg;
         }
 

--- a/src/NServiceBus.RavenDB/SagaPersister/SagaPersister.cs
+++ b/src/NServiceBus.RavenDB/SagaPersister/SagaPersister.cs
@@ -15,38 +15,34 @@ namespace NServiceBus.SagaPersisters.RavenDB
     {
         const string UniqueDocIdKey = "NServiceBus-UniqueDocId";
 
-        public Task Save(IContainSagaData sagaInstance, IDictionary<string, object> correlationProperties, ContextBag context)
+        public async Task Save(IContainSagaData sagaInstance, IDictionary<string, object> correlationProperties, ContextBag context)
         {
-            var session = context.Get<IDocumentSession>();
+            var session = context.Get<IAsyncDocumentSession>();
 
-            session.Store(sagaInstance);
+            await session.StoreAsync(sagaInstance).ConfigureAwait(false);
 
             if (!correlationProperties.Any())
             {
-                return Task.FromResult(0);
+                return;
             }
 
             var correlationProperty = correlationProperties.SingleOrDefault();
 
-
             var value = correlationProperty.Value;
             var id = SagaUniqueIdentity.FormatId(sagaInstance.GetType(), new KeyValuePair<string, object>(correlationProperty.Key, value));
 
-
             var sagaDocId = session.Advanced.DocumentStore.Conventions.FindFullDocumentKeyFromNonStringIdentifier(sagaInstance.Id, sagaInstance.GetType(), false);
 
-            session.Store(new SagaUniqueIdentity
+            await session.StoreAsync(new SagaUniqueIdentity
             {
                 Id = id,
                 SagaId = sagaInstance.Id,
                 UniqueValue = value,
                 SagaDocId = sagaDocId
-            });
+            }).ConfigureAwait(false);
 
-            session.Advanced.GetMetadataFor(sagaInstance)[UniqueDocIdKey] = id;
-
-
-            return Task.FromResult(0);
+            var metadata = await session.Advanced.GetMetadataForAsync(sagaInstance).ConfigureAwait(true);
+            metadata[UniqueDocIdKey] = id;
         }
 
         public Task Update(IContainSagaData saga, ContextBag context)
@@ -55,44 +51,45 @@ namespace NServiceBus.SagaPersisters.RavenDB
             return Task.FromResult(0);
         }
 
-        public Task<T> Get<T>(Guid sagaId, ContextBag context) where T : IContainSagaData
+        public async Task<T> Get<T>(Guid sagaId, ContextBag context) where T : IContainSagaData
         {
-            var session = context.Get<IDocumentSession>();
-            return Task.FromResult(session.Load<T>(sagaId));
+            var session = context.Get<IAsyncDocumentSession>();
+            return await session.LoadAsync<T>(sagaId).ConfigureAwait(false);
         }
 
-        public Task<T> Get<T>(string property, object value, ContextBag context) where T : IContainSagaData
+        public async Task<T> Get<T>(string property, object value, ContextBag context) where T : IContainSagaData
         {
-            var session = context.Get<IDocumentSession>();
+            var session = context.Get<IAsyncDocumentSession>();
 
             var lookupId = SagaUniqueIdentity.FormatId(typeof(T), new KeyValuePair<string, object>(property, value));
 
             //store it in the context to be able to optimize deletes for legacy sagas that don't have the id in metadata
             context.Set(UniqueDocIdKey, lookupId);
 
-            var lookup = session
+            var lookup = await session
                 .Include("SagaDocId") //tell raven to pull the saga doc as well to save us a round-trip
-                .Load<SagaUniqueIdentity>(lookupId);
+                .LoadAsync<SagaUniqueIdentity>(lookupId)
+                .ConfigureAwait(false);
 
             if (lookup != null)
             {
                 return lookup.SagaDocId != null
-                    ? Task.FromResult(session.Load<T>(lookup.SagaDocId)) //if we have a saga id we can just load it
-                    : Get<T>(lookup.SagaId, context); //if not this is a saga that was created pre 3.0.4 so we fallback to a get instead
+                    ? await session.LoadAsync<T>(lookup.SagaDocId).ConfigureAwait(false) //if we have a saga id we can just load it
+                    : await Get<T>(lookup.SagaId, context); //if not this is a saga that was created pre 3.0.4 so we fallback to a get instead
             }
 
-            return Task.FromResult(default(T));
+            return await Task.FromResult(default(T));
         }
 
-        public Task Complete(IContainSagaData saga, ContextBag context)
+        public async Task Complete(IContainSagaData saga, ContextBag context)
         {
-            var session = context.Get<IDocumentSession>();
+            var session = context.Get<IAsyncDocumentSession>();
             session.Delete(saga);
 
             string uniqueDocumentId;
             RavenJToken uniqueDocumentIdMetadata;
-
-            if (session.Advanced.GetMetadataFor(saga).TryGetValue(UniqueDocIdKey, out uniqueDocumentIdMetadata))
+            var metadata = await session.Advanced.GetMetadataForAsync(saga).ConfigureAwait(false);
+            if(metadata.TryGetValue(UniqueDocIdKey, out uniqueDocumentIdMetadata))
             {
                 uniqueDocumentId = uniqueDocumentIdMetadata.Value<string>();
             }
@@ -103,23 +100,20 @@ namespace NServiceBus.SagaPersisters.RavenDB
 
             if (string.IsNullOrEmpty(uniqueDocumentId))
             {
-                var uniqueDoc = session.Query<SagaUniqueIdentity>()
-                    .SingleOrDefault(d => d.SagaId == saga.Id);
+                var uniqueDoc = await session.Query<SagaUniqueIdentity>()
+                    .SingleOrDefaultAsync(d => d.SagaId == saga.Id)
+                    .ConfigureAwait(false);
 
                 if (uniqueDoc != null)
                 {
                     session.Delete(uniqueDoc);
                 }
-
-                return Task.FromResult(0);
             }
 
             session.Advanced.Defer(new DeleteCommandData
             {
                 Key = uniqueDocumentId
             });
-
-            return Task.FromResult(0);
         }
     }
 }

--- a/src/NServiceBus.RavenDB/SagaPersister/SagaPersister.cs
+++ b/src/NServiceBus.RavenDB/SagaPersister/SagaPersister.cs
@@ -78,7 +78,7 @@ namespace NServiceBus.SagaPersisters.RavenDB
                     : await Get<T>(lookup.SagaId, context); //if not this is a saga that was created pre 3.0.4 so we fallback to a get instead
             }
 
-            return await Task.FromResult(default(T));
+            return default(T);
         }
 
         public async Task Complete(IContainSagaData saga, ContextBag context)

--- a/src/NServiceBus.RavenDB/SessionManagement/IAsyncSessionProvider.cs
+++ b/src/NServiceBus.RavenDB/SessionManagement/IAsyncSessionProvider.cs
@@ -1,0 +1,15 @@
+namespace NServiceBus.RavenDB.Persistence
+{
+    using Raven.Client;
+
+    /// <summary>
+    ///     Provides access the the session managed by NServiceBus
+    /// </summary>
+    public interface IAsyncSessionProvider
+    {
+        /// <summary>
+        ///     The async session
+        /// </summary>
+        IAsyncDocumentSession AsyncSession { get; }
+    }
+}

--- a/src/NServiceBus.RavenDB/SessionManagement/ISessionProvider.cs
+++ b/src/NServiceBus.RavenDB/SessionManagement/ISessionProvider.cs
@@ -1,15 +1,11 @@
 namespace NServiceBus.RavenDB.Persistence
 {
-    using Raven.Client;
-
     /// <summary>
     ///     Provides access the the session managed by NServiceBus
     /// </summary>
+    [ObsoleteEx( Message = "Use the 'IAsyncSessionProvider' interface.", RemoveInVersion = "5", TreatAsErrorFromVersion = "4" )]
     public interface ISessionProvider
     {
-        /// <summary>
-        ///     The session
-        /// </summary>
-        IDocumentSession Session { get; }
+        
     }
 }

--- a/src/NServiceBus.RavenDB/SessionManagement/ProvidedAsyncSessionBehavior.cs
+++ b/src/NServiceBus.RavenDB/SessionManagement/ProvidedAsyncSessionBehavior.cs
@@ -5,20 +5,21 @@
     using NServiceBus.Pipeline;
     using Raven.Client;
 
-    class ProvidedSessionBehavior : Behavior<PhysicalMessageProcessingContext>
+    class ProvidedAsyncSessionBehavior : Behavior<PhysicalMessageProcessingContext>
     {
-        public Func<IDocumentSession> GetSession { get; set; }
+
+        public Func<IAsyncDocumentSession> GetAsyncSession { get; set; }
 
         public override Task Invoke(PhysicalMessageProcessingContext context, Func<Task> next)
         {
-            context.Set(GetSession);
+            context.Set(GetAsyncSession);
             return next();
         }
 
         public class Registration : RegisterStep
         {
             public Registration()
-                : base("ProvidedRavenDbSession", typeof(ProvidedSessionBehavior), "Makes sure that there is a RavenDB IDocumentSession available on the pipeline")
+                : base("ProvidedRavenDbAsyncSession", typeof(ProvidedAsyncSessionBehavior), "Makes sure that there is a RavenDB IAsyncDocumentSession available on the pipeline")
             {
                 InsertAfter(WellKnownStep.ExecuteUnitOfWork);
                 InsertBeforeIfExists(WellKnownStep.InvokeSaga);

--- a/src/NServiceBus.RavenDB/SessionManagement/RavenDbStorageSession.cs
+++ b/src/NServiceBus.RavenDB/SessionManagement/RavenDbStorageSession.cs
@@ -18,12 +18,12 @@
         protected override void Setup(FeatureConfigurationContext context)
         {
             // Check to see if the user provided us with a shared session to work with before we go and create our own to inject into the pipeline
-            var getSessionFunc = context.Settings.GetOrDefault<Func<IDocumentSession>>(RavenDbSettingsExtensions.SharedSessionSettingsKey);
-            if (getSessionFunc != null)
+            var getAsyncSessionFunc = context.Settings.GetOrDefault<Func<IAsyncDocumentSession>>( RavenDbSettingsExtensions.SharedAsyncSessionSettingsKey );
+            if( getAsyncSessionFunc != null )
             {
-                context.Container.ConfigureComponent<ProvidedSessionBehavior>(DependencyLifecycle.InstancePerCall)
-                    .ConfigureProperty(x => x.GetSession, getSessionFunc);
-                context.Pipeline.Register<ProvidedSessionBehavior.Registration>();
+                context.Container.ConfigureComponent<ProvidedAsyncSessionBehavior>(DependencyLifecycle.InstancePerCall)
+                    .ConfigureProperty(x => x.GetAsyncSession, getAsyncSessionFunc);
+                context.Pipeline.Register<ProvidedAsyncSessionBehavior.Registration>();
                 return;
             }
 
@@ -47,9 +47,9 @@
                 remoteStorage.TransactionRecoveryStorage = new IsolatedStorageTransactionRecoveryStorage();
             }
 
-            context.Container.ConfigureComponent<RavenSessionProvider>(DependencyLifecycle.InstancePerCall);
+            context.Container.ConfigureComponent<RavenAsyncSessionProvider>(DependencyLifecycle.InstancePerCall);
             context.Container.RegisterSingleton<IDocumentStoreWrapper>(new DocumentStoreWrapper(store));
-            context.Pipeline.Register<OpenSessionBehavior.Registration>();
+            context.Pipeline.Register<OpenAsyncSessionBehavior.Registration>();
         }
     }
 }

--- a/src/NServiceBus.RavenDB/Subscriptions/SubscriptionPersister.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/SubscriptionPersister.cs
@@ -28,7 +28,7 @@ namespace NServiceBus.Unicast.Subscriptions.RavenDB
             {
                 try
                 {
-                    using (var session = OpenSession())
+                    using (var session = OpenAsyncSession())
                     {
                         foreach (var messageType in msgTypes)
                         {
@@ -66,7 +66,7 @@ namespace NServiceBus.Unicast.Subscriptions.RavenDB
 
         public async Task Unsubscribe(string client, IEnumerable<MessageType> messageTypes, ContextBag context)
         {
-            using (var session = OpenSession())
+            using (var session = OpenAsyncSession())
             {
                 foreach (var messageType in messageTypes)
                 {
@@ -94,7 +94,7 @@ namespace NServiceBus.Unicast.Subscriptions.RavenDB
             var ids = messageTypes.Select(Subscription.FormatId)
                 .ToList();
 
-            using (var session = OpenSession())
+            using (var session = OpenAsyncSession())
             {
                 var subscriptions = await session.LoadAsync<Subscription>(ids).ConfigureAwait(false);
 
@@ -104,7 +104,7 @@ namespace NServiceBus.Unicast.Subscriptions.RavenDB
             }
         }
 
-        IAsyncDocumentSession OpenSession()
+        IAsyncDocumentSession OpenAsyncSession()
         {
             var session = documentStore.OpenAsyncSession();
             session.Advanced.AllowNonAuthoritativeInformation = false;


### PR DESCRIPTION
Connects to #113 

### What's included:

* Make saga persister async
* Make the gateway persister async
* Outbox support for async/await
* timeouts support for async/await  
* Ensures all the tests are moved to async/await

### What's missing: 

* 3 failing tests for some weird/yet unknown reason
* Provide the document session to handlers via ext method on handler context
* If NUnit tests are run via the Visual Studio test runner adapter there are test failures (other than the 3 mentioned above) due to some (identified) RavenDB 3.0 Embedded behavior, when run via the R# test runner they run fine