### PR TITLE
Relaxed version constraints between client and server

### DIFF
--- a/src/NServiceBus.RavenDB.Tests/Persistence/TestConnectionVerifier.cs
+++ b/src/NServiceBus.RavenDB.Tests/Persistence/TestConnectionVerifier.cs
@@ -1,27 +1,11 @@
 ﻿namespace NServiceBus.RavenDB.Tests.Persistence
 {
-    using System;
     using NServiceBus.RavenDB.Internal;
     using NUnit.Framework;
     using Raven.Client.Document;
 
     public class TestConnectionVerifier
     {
-        [Test]
-        public void Throws_on_ravendb3_server()
-        {
-            using (var documentStore = new DocumentStore
-            {
-                Url = "http://localhost:8083", // RavenDB 3.0 is running on port 8083 on the test agents
-                DefaultDatabase = "Test"
-            })
-            {
-                documentStore.Initialize();
-
-                Assert.Throws <InvalidOperationException>(() => ConnectionVerifier.VerifyConnectionToRavenDBServer(documentStore));
-            }
-        }
-
         [Test]
         public void Doesnt_throw_on_ravendb25_server()
         {

--- a/src/NServiceBus.RavenDB/Internal/ConnectionVerifier.cs
+++ b/src/NServiceBus.RavenDB/Internal/ConnectionVerifier.cs
@@ -100,12 +100,12 @@ Further instructions can be found at: http://particular.net/articles/using-raven
                 {
                     return false;
                 }
-                return !string.IsNullOrEmpty(ProductVersion) && ProductVersion.StartsWith("2.5") && buildVersion >= 2900;
+                return !string.IsNullOrEmpty(ProductVersion) && buildVersion >= 2908;
             }
 
             public override string ToString()
             {
-                return string.Format("Product version: {0}, Build version: {1}", ProductVersion, BuildVersion);
+                return $"Product version: {ProductVersion}, Build version: {BuildVersion}";
             }
         }
     }


### PR DESCRIPTION
## Who's affected
* Any user trying to use NServiceBus.RavenDB with a newer server version greater than 3.0

## Symptoms 

When the RavenDB server is upgraded to 3.0 or higher and the host is started the following exception occurs:

```
System.InvalidOperationException: The RavenDB server you have specified is detected to be Product version: 3.0.0 / cdc39ac / , Build version: 3800. NServiceBus requires RavenDB version 2.5 build 2908 or higher to operate correctly. Please update your RavenDB server.
```

## Description
* Relaxed version constraints between client and server, fixes #117