### PR TITLE
Remove EnsureDatabaseExists call

### DIFF
--- a/src/NServiceBus.RavenDB.Tests/Persistence/DocumentStoreExtensionsForVoron.cs
+++ b/src/NServiceBus.RavenDB.Tests/Persistence/DocumentStoreExtensionsForVoron.cs
@@ -22,7 +22,6 @@
                     }
             });
             store.DefaultDatabase = dbName;
-            store.DatabaseCommands.GlobalAdmin.EnsureDatabaseExists(dbName);
             return new VoronTestDeleter(store, dbName);
         }
 


### PR DESCRIPTION
This extra call causes persistence tests to fail in release mode.
cc / @mauroservienti  @DavidBoike 