### PR TITLE
[WIP] Subscription per MessageType & Endpoint

### DIFF
--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_converting_old_subscription_to_new_subscription.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_converting_old_subscription_to_new_subscription.cs
@@ -25,7 +25,7 @@
             store.Listeners.RegisterListener(new FakeSubscriptionClrType());
             store.Listeners.RegisterListener(new SubscriptionV1toV2Converter());
 
-            persister = new SubscriptionPersister(store);
+            persister = new SubscriptionPersister(store, new AggregateSubscriptionDocumentAccess());
         }
 
         [Test]

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_listing_subscribers_for_a_non_existing_message_type.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_listing_subscribers_for_a_non_existing_message_type.cs
@@ -11,7 +11,7 @@ public class When_listing_subscribers_for_a_non_existing_message_type : RavenDBP
     [Test]
     public async Task No_subscribers_should_be_returned()
     {
-        var persister = new SubscriptionPersister(store);
+        var persister = new SubscriptionPersister(store, new AggregateSubscriptionDocumentAccess());
         var subscriptionsForMessageType = await persister.GetSubscriberAddressesForMessage(MessageTypes.MessageA, new ContextBag());
 
         Assert.AreEqual(0, subscriptionsForMessageType.Count());

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_listing_subscribers_for_a_non_existing_message_type.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_listing_subscribers_for_a_non_existing_message_type.cs
@@ -11,7 +11,7 @@ public class When_listing_subscribers_for_a_non_existing_message_type : RavenDBP
     [Test]
     public async Task No_subscribers_should_be_returned()
     {
-        var persister = new SubscriptionPersister(store, new AggregateSubscriptionDocumentAccess());
+        var persister = new SubscriptionPersister(store, new IndividualSubscriptionDocumentAccess());
         var subscriptionsForMessageType = await persister.GetSubscriberAddressesForMessage(MessageTypes.MessageA, new ContextBag());
 
         Assert.AreEqual(0, subscriptionsForMessageType.Count());

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_listing_subscribers_for_message_types.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_listing_subscribers_for_message_types.cs
@@ -12,7 +12,7 @@ public class When_listing_subscribers_for_message_types : RavenDBPersistenceTest
     [Test]
     public async Task The_names_of_all_subscribers_should_be_returned()
     {
-        var storage = new SubscriptionPersister(store, new AggregateSubscriptionDocumentAccess());
+        var storage = new SubscriptionPersister(store, new IndividualSubscriptionDocumentAccess());
         var context = new ContextBag();
 
         await storage.Subscribe(TestClients.ClientA, MessageTypes.MessageA, context);
@@ -34,7 +34,7 @@ public class When_listing_subscribers_for_message_types : RavenDBPersistenceTest
     [Test]
     public async Task Duplicates_should_not_be_generated_for_interface_inheritance_chains()
     {
-        var storage = new SubscriptionPersister(store, new AggregateSubscriptionDocumentAccess());
+        var storage = new SubscriptionPersister(store, new IndividualSubscriptionDocumentAccess());
         var context = new ContextBag();
 
         await storage.Subscribe(TestClients.ClientA, new[]

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_listing_subscribers_for_message_types.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_listing_subscribers_for_message_types.cs
@@ -12,7 +12,7 @@ public class When_listing_subscribers_for_message_types : RavenDBPersistenceTest
     [Test]
     public async Task The_names_of_all_subscribers_should_be_returned()
     {
-        var storage = new SubscriptionPersister(store);
+        var storage = new SubscriptionPersister(store, new AggregateSubscriptionDocumentAccess());
         var context = new ContextBag();
 
         await storage.Subscribe(TestClients.ClientA, MessageTypes.MessageA, context);
@@ -34,7 +34,7 @@ public class When_listing_subscribers_for_message_types : RavenDBPersistenceTest
     [Test]
     public async Task Duplicates_should_not_be_generated_for_interface_inheritance_chains()
     {
-        var storage = new SubscriptionPersister(store);
+        var storage = new SubscriptionPersister(store, new AggregateSubscriptionDocumentAccess());
         var context = new ContextBag();
 
         await storage.Subscribe(TestClients.ClientA, new[]

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_a_subscription_message.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_a_subscription_message.cs
@@ -23,14 +23,14 @@ public class When_receiving_a_subscription_message : RavenDBPersistenceTestBase
             new MessageType("MessageType2", "1.0.0.0")
         };
 
-        var storage = new SubscriptionPersister(store, new AggregateSubscriptionDocumentAccess());
+        var storage = new SubscriptionPersister(store, new IndividualSubscriptionDocumentAccess());
 
         await storage.Subscribe(clientEndpoint, messageTypes, new ContextBag());
 
         using (var session = store.OpenAsyncSession())
         {
             var subscriptions = await session
-                .Query<Subscription>()
+                .Query<SubscriptionDocument>()
                 .Customize(c => c.WaitForNonStaleResults())
                 .CountAsync();
 

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_a_subscription_message.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_a_subscription_message.cs
@@ -23,7 +23,7 @@ public class When_receiving_a_subscription_message : RavenDBPersistenceTestBase
             new MessageType("MessageType2", "1.0.0.0")
         };
 
-        var storage = new SubscriptionPersister(store);
+        var storage = new SubscriptionPersister(store, new AggregateSubscriptionDocumentAccess());
 
         await storage.Subscribe(clientEndpoint, messageTypes, new ContextBag());
 

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_an_unsubscription_message.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_an_unsubscription_message.cs
@@ -10,7 +10,7 @@ public class When_receiving_an_unsubscribe_message : RavenDBPersistenceTestBase
     [Test]
     public async Task All_subscription_entries_for_specified_message_types_should_be_removed()
     {
-        var storage = new SubscriptionPersister(store);
+        var storage = new SubscriptionPersister(store, new AggregateSubscriptionDocumentAccess());
         var context = new ContextBag();
 
         await storage.Subscribe(TestClients.ClientA, MessageTypes.All, context);

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_an_unsubscription_message.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_an_unsubscription_message.cs
@@ -10,7 +10,7 @@ public class When_receiving_an_unsubscribe_message : RavenDBPersistenceTestBase
     [Test]
     public async Task All_subscription_entries_for_specified_message_types_should_be_removed()
     {
-        var storage = new SubscriptionPersister(store, new AggregateSubscriptionDocumentAccess());
+        var storage = new SubscriptionPersister(store, new IndividualSubscriptionDocumentAccess());
         var context = new ContextBag();
 
         await storage.Subscribe(TestClients.ClientA, MessageTypes.All, context);

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_duplicate_subscription_messages.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_duplicate_subscription_messages.cs
@@ -16,7 +16,7 @@ public class When_receiving_duplicate_subscription_messages : RavenDBPersistence
     [Test]
     public async Task should_not_create_additional_db_rows()
     {
-        var storage = new SubscriptionPersister(store, new AggregateSubscriptionDocumentAccess());
+        var storage = new SubscriptionPersister(store, new IndividualSubscriptionDocumentAccess());
 
         await storage.Subscribe(new Subscriber("testEndPoint@localhost", new Endpoint("testEndPoint")), new List<MessageType>
         {
@@ -31,7 +31,7 @@ public class When_receiving_duplicate_subscription_messages : RavenDBPersistence
         using (var session = store.OpenAsyncSession())
         {
             var subscriptions = await session
-                .Query<Subscription>()
+                .Query<SubscriptionDocument>()
                 .Customize(c => c.WaitForNonStaleResults())
                 .CountAsync();
 

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_duplicate_subscription_messages.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_duplicate_subscription_messages.cs
@@ -16,7 +16,7 @@ public class When_receiving_duplicate_subscription_messages : RavenDBPersistence
     [Test]
     public async Task should_not_create_additional_db_rows()
     {
-        var storage = new SubscriptionPersister(store);
+        var storage = new SubscriptionPersister(store, new AggregateSubscriptionDocumentAccess());
 
         await storage.Subscribe(new Subscriber("testEndPoint@localhost", new Endpoint("testEndPoint")), new List<MessageType>
         {

--- a/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
+++ b/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Subscriptions\MessageTypeConverter.cs" />
     <Compile Include="Subscriptions\RavenDbSubscriptionSettingsExtensions.cs" />
     <Compile Include="Subscriptions\RavenDbSubscriptionStorage.cs" />
+    <Compile Include="Subscriptions\SubscriptionDocument.cs" />
     <Compile Include="Subscriptions\SubscriptionClient.cs" />
     <Compile Include="Subscriptions\SubscriptionPersister.cs" />
     <Compile Include="Subscriptions\Subscription.cs" />
@@ -132,6 +133,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="FodyWeavers.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="AntiCorruption\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\GitVersionTask.2.0.1\Build\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.2.0.1\Build\GitVersionTask.targets')" />

--- a/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
+++ b/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
@@ -109,6 +109,9 @@
     <Compile Include="SagaPersister\SagaPersister.cs" />
     <Compile Include="SagaPersister\SagaUniqueIdentity.cs" />
     <Compile Include="SessionManagement\SynchronizedStorage.cs" />
+    <Compile Include="Subscriptions\AggregateSubscriptionDocumentAccess.cs" />
+    <Compile Include="Subscriptions\IndividualSubscriptionDocumentAccess.cs" />
+    <Compile Include="Subscriptions\ISubscriptionAccess.cs" />
     <Compile Include="Subscriptions\MessageTypeConverter.cs" />
     <Compile Include="Subscriptions\RavenDbSubscriptionSettingsExtensions.cs" />
     <Compile Include="Subscriptions\RavenDbSubscriptionStorage.cs" />

--- a/src/NServiceBus.RavenDB/Subscriptions/AggregateSubscriptionDocumentAccess.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/AggregateSubscriptionDocumentAccess.cs
@@ -1,0 +1,62 @@
+namespace NServiceBus.Unicast.Subscriptions.RavenDB
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
+    using NServiceBus.RavenDB.Persistence.SubscriptionStorage;
+    using NServiceBus.Routing;
+    using NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions;
+    using Raven.Client;
+
+    class AggregateSubscriptionDocumentAccess : ISubscriptionAccess
+    {
+        public async Task Subscribe(MessageType messageType, SubscriptionClient subscriptionClient, IAsyncDocumentSession session)
+        {
+            var subscriptionDocId = Subscription.FormatId(messageType);
+
+            var subscription = await session.LoadAsync<Subscription>(subscriptionDocId).ConfigureAwait(false);
+
+            if (subscription == null)
+            {
+                subscription = new Subscription
+                {
+                    Id = subscriptionDocId,
+                    MessageType = messageType,
+                    Subscribers = new List<SubscriptionClient>()
+                };
+
+                await session.StoreAsync(subscription).ConfigureAwait(false);
+            }
+
+            if (!subscription.Subscribers.Contains(subscriptionClient))
+            {
+                subscription.Subscribers.Add(subscriptionClient);
+            }
+        }
+
+        public async Task Unsubscribe(MessageType messageType, SubscriptionClient subscriptionClient, IAsyncDocumentSession session)
+        {
+            var subscriptionDocId = Subscription.FormatId(messageType);
+
+            var subscription = await session.LoadAsync<Subscription>(subscriptionDocId).ConfigureAwait(false);
+
+            if (subscription.Subscribers.Contains(subscriptionClient))
+            {
+                subscription.Subscribers.Remove(subscriptionClient);
+            }
+        }
+
+        public async Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IReadOnlyCollection<MessageType> messageTypes, ContextBag context, IAsyncDocumentSession session)
+        {
+            var ids = messageTypes.Select(Subscription.FormatId).ToList();
+
+            var subscriptions = await session.LoadAsync<Subscription>(ids).ConfigureAwait(false);
+
+            return subscriptions.Where(s => s != null)
+                .SelectMany(s => s.Subscribers)
+                .Distinct()
+                .Select(c => new Subscriber(c.TransportAddress, new Endpoint(c.Endpoint)));
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB/Subscriptions/ISubscriptionAccess.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/ISubscriptionAccess.cs
@@ -1,0 +1,16 @@
+namespace NServiceBus.Unicast.Subscriptions.RavenDB
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
+    using NServiceBus.RavenDB.Persistence.SubscriptionStorage;
+    using NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions;
+    using Raven.Client;
+
+    interface ISubscriptionAccess
+    {
+        Task Subscribe(MessageType messageType, SubscriptionClient subscriptionClient, IAsyncDocumentSession session);
+        Task Unsubscribe(MessageType messageType, SubscriptionClient subscriptionClient, IAsyncDocumentSession session);
+        Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IReadOnlyCollection<MessageType> messageTypes, ContextBag context, IAsyncDocumentSession session);
+    }
+}

--- a/src/NServiceBus.RavenDB/Subscriptions/IndividualSubscriptionDocumentAccess.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/IndividualSubscriptionDocumentAccess.cs
@@ -1,0 +1,66 @@
+namespace NServiceBus.Unicast.Subscriptions.RavenDB
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
+    using NServiceBus.RavenDB.Persistence.SubscriptionStorage;
+    using NServiceBus.Routing;
+    using NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions;
+    using Raven.Client;
+
+    class IndividualSubscriptionDocumentAccess : ISubscriptionAccess
+    {
+        public async Task Subscribe(MessageType messageType, SubscriptionClient subscriptionClient, IAsyncDocumentSession session)
+        {
+            var subscriptionDocId = SubscriptionDocument.FormatId(messageType, subscriptionClient);
+
+            var subscription = await session.LoadAsync<SubscriptionDocument>(subscriptionDocId).ConfigureAwait(false);
+
+            if (subscription == null)
+            {
+                subscription = new SubscriptionDocument
+                {
+                    Id = subscriptionDocId,
+                    MessageType = messageType,
+                    SubscriptionClient = subscriptionClient
+                };
+
+                await session.StoreAsync(subscription, subscriptionDocId).ConfigureAwait(false);
+            }
+        }
+
+        public async Task Unsubscribe(MessageType messageType, SubscriptionClient subscriptionClient, IAsyncDocumentSession session)
+        {
+            var subscriptionDocId = SubscriptionDocument.FormatId(messageType, subscriptionClient);
+
+            var subscriptionToDelete = await session.LoadAsync<SubscriptionDocument>(subscriptionDocId).ConfigureAwait(false);
+
+            if (subscriptionToDelete != null)
+            {
+                session.Delete(subscriptionToDelete);
+            }
+        }
+
+        public async Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IReadOnlyCollection<MessageType> messageTypes, ContextBag context, IAsyncDocumentSession session)
+        {
+            var subscriptions = new List<SubscriptionDocument>();
+
+            foreach (var messageType in messageTypes)
+            {
+                var startOfId = SubscriptionDocument.IdStart(messageType);
+                subscriptions.AddRange(
+                    await session.Advanced.LoadStartingWithAsync<SubscriptionDocument>(startOfId).ConfigureAwait(false)
+                    );
+            }
+
+            return
+                subscriptions
+                    .Select(s => s.SubscriptionClient)
+                    .Distinct()
+                    .Select(c =>
+                        new Subscriber(c.TransportAddress, new Endpoint(c.Endpoint))
+                    );
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionSettingsExtensions.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionSettingsExtensions.cs
@@ -11,6 +11,8 @@
     {
         internal const string SettingsKey = "RavenDbDocumentStore/Subscription";
 
+        internal const string DoNotUpgradeSubscriptionSchema = "RavenDbDocumentStore/Subscription/DoNotUpgradeSchema";
+
         /// <summary>
         ///     Configures the given document store to be used when storing subscriptions
         /// </summary>

--- a/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionStorage.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionStorage.cs
@@ -1,13 +1,16 @@
 ﻿namespace NServiceBus.Features
 {
     using System;
+    using System.Linq;
     using NServiceBus.RavenDB;
     using NServiceBus.RavenDB.Internal;
     using NServiceBus.RavenDB.Persistence.SubscriptionStorage;
+    using NServiceBus.Unicast.Subscriptions;
     using NServiceBus.Unicast.Subscriptions.RavenDB;
     using Raven.Client;
     using Raven.Client.Document;
     using Raven.Client.Document.DTC;
+    using Raven.Client.Linq;
 
     class RavenDbSubscriptionStorage : Feature
     {
@@ -45,7 +48,53 @@
 
             store.Listeners.RegisterListener(new SubscriptionV1toV2Converter());
 
-            context.Container.ConfigureComponent(() => new SubscriptionPersister(store), DependencyLifecycle.InstancePerCall);
+            var doNotUpgradeSubscriptionSchema = 
+                context.Settings.GetOrDefault<bool>(RavenDbSubscriptionSettingsExtensions.DoNotUpgradeSubscriptionSchema);
+
+            ISubscriptionAccess subscriptionAccessMethod;
+
+            if (doNotUpgradeSubscriptionSchema)
+            {
+                subscriptionAccessMethod = new AggregateSubscriptionDocumentAccess();
+            }
+            else
+            {
+                ConvertToIndividualDocumentSchema(store);
+                subscriptionAccessMethod = new IndividualSubscriptionDocumentAccess();
+            }
+
+            context.Container.ConfigureComponent(() => new SubscriptionPersister(store, subscriptionAccessMethod), DependencyLifecycle.InstancePerCall);
+        }
+
+        private static void ConvertToIndividualDocumentSchema(IDocumentStore store)
+        {
+            using (var session = store.OpenSession())
+            {
+                var legacyDocuments = session.Load<Subscription>();
+                var newDocuments = session.Load<SubscriptionDocument>();
+
+                foreach (var legacyDocument in legacyDocuments)
+                {
+                    foreach (var subscriber in legacyDocument.Subscribers)
+                    {
+                        if (!newDocuments.Any(d => DocumentMatches(d, legacyDocument.MessageType, subscriber)))
+                        {
+                            session.Store(new SubscriptionDocument()
+                            {
+                                MessageType = legacyDocument.MessageType,
+                                SubscriptionClient = subscriber
+                            });
+                        }
+                    }
+                }
+
+                session.SaveChanges();
+            }
+        }
+
+        private static bool DocumentMatches(SubscriptionDocument newDoc, MessageType messageType, SubscriptionClient client)
+        {
+            return messageType.Equals(newDoc.MessageType) && client.Equals(newDoc.SubscriptionClient);
         }
     }
 }

--- a/src/NServiceBus.RavenDB/Subscriptions/Subscription.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/Subscription.cs
@@ -7,6 +7,9 @@ namespace NServiceBus.RavenDB.Persistence.SubscriptionStorage
     using NServiceBus.Unicast.Subscriptions;
     using Raven.Imports.Newtonsoft.Json;
 
+    /// <summary>
+    /// Legacy subscription format as of NServiceBus version 6
+    /// </summary>
     class Subscription
     {
         public string Id { get; set; }

--- a/src/NServiceBus.RavenDB/Subscriptions/SubscriptionClient.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/SubscriptionClient.cs
@@ -1,5 +1,8 @@
 ﻿namespace NServiceBus.RavenDB.Persistence.SubscriptionStorage
 {
+    /// <summary>
+    /// This is an anti-corruption layer against changes in NServiceBus Core
+    /// </summary>
     class SubscriptionClient
     {
         public string TransportAddress { get; set; }

--- a/src/NServiceBus.RavenDB/Subscriptions/SubscriptionDocument.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/SubscriptionDocument.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.RavenDB.Persistence.SubscriptionStorage
 {
+    using System.Collections.Generic;
     using NServiceBus.Unicast.Subscriptions;
     using Raven.Imports.Newtonsoft.Json;
 
@@ -12,18 +13,21 @@ namespace NServiceBus.RavenDB.Persistence.SubscriptionStorage
 
         public SubscriptionClient SubscriptionClient { get; set; }
 
+        public static List<string> PossibleIdPrefixes(MessageType messageType)
+        {
+            var possibleIdPrefix = new List<string>();
+
+            return possibleIdPrefix;
+        }
+
         public static string IdStart(MessageType messageType)
         {
-            var startOfId = $"Subscription/{messageType.TypeName}/";
-
-            return startOfId;
+            return $"Subscription/{messageType.TypeName}/{messageType.Version.Major}/";
         }
 
         public static string FormatId(MessageType messageType, SubscriptionClient client)
         {
-            var documentId = IdStart(messageType) + $"{client.Endpoint}/{messageType.Version.Major}";
-
-            return documentId;
+            return IdStart(messageType) + $"{client.Endpoint}";
         }
     }
 }

--- a/src/NServiceBus.RavenDB/Subscriptions/SubscriptionDocument.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/SubscriptionDocument.cs
@@ -12,9 +12,16 @@ namespace NServiceBus.RavenDB.Persistence.SubscriptionStorage
 
         public SubscriptionClient SubscriptionClient { get; set; }
 
+        public static string IdStart(MessageType messageType)
+        {
+            var startOfId = $"Subscription/{messageType.TypeName}/";
+
+            return startOfId;
+        }
+
         public static string FormatId(MessageType messageType, SubscriptionClient client)
         {
-            var documentId = $"Subscription/{messageType.TypeName}/{client.Endpoint}/{messageType.Version.Major}";
+            var documentId = IdStart(messageType) + $"{client.Endpoint}/{messageType.Version.Major}";
 
             return documentId;
         }

--- a/src/NServiceBus.RavenDB/Subscriptions/SubscriptionDocument.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/SubscriptionDocument.cs
@@ -1,11 +1,13 @@
 namespace NServiceBus.RavenDB.Persistence.SubscriptionStorage
 {
     using NServiceBus.Unicast.Subscriptions;
+    using Raven.Imports.Newtonsoft.Json;
 
     class SubscriptionDocument
     {
         public string Id { get; set; }
 
+        [JsonConverter(typeof(MessageTypeConverter))]
         public MessageType MessageType { get; set; }
 
         public SubscriptionClient SubscriptionClient { get; set; }

--- a/src/NServiceBus.RavenDB/Subscriptions/SubscriptionDocument.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/SubscriptionDocument.cs
@@ -1,0 +1,20 @@
+namespace NServiceBus.RavenDB.Persistence.SubscriptionStorage
+{
+    using NServiceBus.Unicast.Subscriptions;
+
+    class SubscriptionDocument
+    {
+        public string Id { get; set; }
+
+        public MessageType MessageType { get; set; }
+
+        public SubscriptionClient SubscriptionClient { get; set; }
+
+        public static string FormatId(MessageType messageType, SubscriptionClient client)
+        {
+            var documentId = $"Subscription/{messageType.TypeName}/{client.Endpoint}/{messageType.Version.Major}";
+
+            return documentId;
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB/Subscriptions/SubscriptionPersister.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/SubscriptionPersister.cs
@@ -1,61 +1,25 @@
 namespace NServiceBus.Unicast.Subscriptions.RavenDB
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-    using NServiceBus.Extensibility;
+    using Extensibility;
     using NServiceBus.RavenDB.Persistence.SubscriptionStorage;
     using NServiceBus.Routing;
-    using NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions;
+    using MessageDrivenSubscriptions;
     using Raven.Abstractions.Exceptions;
     using Raven.Client;
 
-    class SubscriptionPersister : ISubscriptionStorage
+    interface ISubscriptionAccess
     {
-        public SubscriptionPersister(IDocumentStore store)
-        {
-            documentStore = store;
-        }
+        Task Subscribe(MessageType messageType, SubscriptionClient subscriptionClient, IAsyncDocumentSession session);
+        Task Unsubscribe(MessageType messageType, SubscriptionClient subscriptionClient, IAsyncDocumentSession session);
+    }
 
-        public async Task Subscribe(Subscriber subscriber, IReadOnlyCollection<MessageType> messageTypes, ContextBag context)
-        {
-            //When the subscriber is running V6 and UseLegacyMessageDrivenSubscriptionMode is enabled at the subscriber the 'subscriber.Endpoint' value is null
-            var endpoint = subscriber.Endpoint?.ToString() ?? subscriber.TransportAddress.Split('@').First();
-            var subscriptionClient = new SubscriptionClient { TransportAddress = subscriber.TransportAddress, Endpoint = endpoint };
-
-            using (var session = OpenAsyncSession())
-            {
-                foreach (var messageType in messageTypes)
-                {
-                    await PersistIndividualDocument(messageType, subscriptionClient, session);
-                    await TrySavingLegacySubscriptions(messageType, subscriptionClient, session);
-                }
-            }
-        }
-
-        private async Task TrySavingLegacySubscriptions(MessageType messageType, SubscriptionClient subscriptionClient, IAsyncDocumentSession session)
-        {
-            if (NoLegacyDocumentExists(messageType, session))
-            {
-                return;
-            }
-
-            var attempts = 0;
-            do
-            {
-                try
-                {
-                    await PersistToAggregateDocument(messageType, subscriptionClient, session);
-                    break;
-                }
-                catch (ConcurrencyException)
-                {
-                    attempts++;
-                }
-            } while (attempts < 5);
-        }
-
-        private static async Task PersistIndividualDocument(MessageType messageType, SubscriptionClient subscriptionClient, IAsyncDocumentSession session)
+    class IndividualSubscriptionDocumentAccess : ISubscriptionAccess
+    {
+        public async Task Subscribe(MessageType messageType, SubscriptionClient subscriptionClient, IAsyncDocumentSession session)
         {
             var subscriptionDocId = SubscriptionDocument.FormatId(messageType, subscriptionClient);
 
@@ -72,11 +36,33 @@ namespace NServiceBus.Unicast.Subscriptions.RavenDB
 
                 await session.StoreAsync(subscription).ConfigureAwait(false);
             }
-
-            await session.SaveChangesAsync().ConfigureAwait(false);
         }
 
-        private async Task PersistToAggregateDocument(MessageType messageType, SubscriptionClient subscriptionClient, IAsyncDocumentSession session)
+        public Task Unsubscribe(MessageType messageType, SubscriptionClient subscriptionClient, IAsyncDocumentSession session)
+        {
+            var subscriptionDocId = SubscriptionDocument.FormatId(messageType, subscriptionClient);
+
+            session.Delete(subscriptionDocId);
+
+            return Task.FromResult(0);
+        }
+    }
+
+    class AggregateSubscriptionDocumentAccess : ISubscriptionAccess
+    {
+        public async Task Unsubscribe(MessageType messageType, SubscriptionClient subscriptionClient, IAsyncDocumentSession session)
+        {
+            var subscriptionDocId = Subscription.FormatId(messageType);
+
+            var subscription = await session.LoadAsync<Subscription>(subscriptionDocId).ConfigureAwait(false);
+
+            if (subscription.Subscribers.Contains(subscriptionClient))
+            {
+                subscription.Subscribers.Remove(subscriptionClient);
+            }
+        }
+
+        public async Task Subscribe(MessageType messageType, SubscriptionClient subscriptionClient, IAsyncDocumentSession session)
         {
             var subscriptionDocId = Subscription.FormatId(messageType);
 
@@ -98,40 +84,43 @@ namespace NServiceBus.Unicast.Subscriptions.RavenDB
             {
                 subscription.Subscribers.Add(subscriptionClient);
             }
-
-            await session.SaveChangesAsync().ConfigureAwait(false);
         }
 
-        public async Task Unsubscribe(Subscriber subscriber, IReadOnlyCollection<MessageType> messageTypes, ContextBag context)
+    }
+
+    class SubscriptionPersister : ISubscriptionStorage
+    {
+        public SubscriptionPersister(IDocumentStore store, ISubscriptionAccess access)
         {
-            var subscriptionClient = new SubscriptionClient { TransportAddress = subscriber.TransportAddress, Endpoint = subscriber.Endpoint.ToString() };
-
-            using (var session = OpenAsyncSession())
-            {
-                foreach (var messageType in messageTypes)
-                {
-                    await RemoveSubscriptionDocument(messageType, subscriptionClient, session);
-                    await TryUnsubscribingFromLegacy(messageType, subscriptionClient, session);
-                }
-
-                await session.SaveChangesAsync().ConfigureAwait(false);
-            }
+            documentStore = store;
+            subscriptionAccess = access;
         }
 
-        private async Task TryUnsubscribingFromLegacy(MessageType messageType, SubscriptionClient subscriptionClient, IAsyncDocumentSession session)
+        public async Task Subscribe(Subscriber subscriber, IReadOnlyCollection<MessageType> messageTypes, ContextBag context)
         {
-            if (NoLegacyDocumentExists(messageType, session))
+            //When the subscriber is running V6 and UseLegacyMessageDrivenSubscriptionMode is enabled at the subscriber the 'subscriber.Endpoint' value is null
+            var endpoint = subscriber.Endpoint?.ToString() ?? subscriber.TransportAddress.Split('@').First();
+            var subscriptionClient = new SubscriptionClient
             {
-                return;
-            }
+                TransportAddress = subscriber.TransportAddress,
+                Endpoint = endpoint
+            };
 
             var attempts = 0;
+            // Remove this do while and try catch when we eliminate AggregateSubscriptionDocumentAccess
             do
             {
                 try
                 {
-                    await UnsubscribeFromAggregateDocument(messageType, subscriptionClient, session);
-                    break;
+                    using (var session = OpenAsyncSession())
+                    {
+                        foreach (var messageType in messageTypes)
+                        {
+                            await subscriptionAccess.Subscribe(messageType, subscriptionClient, session);
+                        }
+
+                        await session.SaveChangesAsync().ConfigureAwait(false);
+                    }
                 }
                 catch (ConcurrencyException)
                 {
@@ -140,40 +129,22 @@ namespace NServiceBus.Unicast.Subscriptions.RavenDB
             } while (attempts < 5);
         }
 
-        private static bool NoLegacyDocumentExists(MessageType messageType, IAsyncDocumentSession session)
-        {
-            var legacySubscriptionDocId = Subscription.FormatId(messageType);
-            //We load metadata to avoid loading the entire document if we don't have to
-            var legacyDocumentMetadata = session.Advanced.DocumentStore.DatabaseCommands.Head(legacySubscriptionDocId);
 
-            if (legacyDocumentMetadata == null)
+        public async Task Unsubscribe(Subscriber subscriber, IReadOnlyCollection<MessageType> messageTypes, ContextBag context)
+        {
+            var subscriptionClient = new SubscriptionClient
             {
-                // There is no need to support the legacy format
-                return true;
-            }
-            return false;
-        }
+                TransportAddress = subscriber.TransportAddress,
+                Endpoint = subscriber.Endpoint.ToString()
+            };
 
-        private static async Task RemoveSubscriptionDocument(MessageType messageType, SubscriptionClient subscriptionClient, IAsyncDocumentSession session)
-        {
-            var subscriptionDocId = SubscriptionDocument.FormatId(messageType, subscriptionClient);
-
-            session.Delete(subscriptionDocId);
-
-            await session.SaveChangesAsync().ConfigureAwait(false);
-        }
-
-        private async Task UnsubscribeFromAggregateDocument(MessageType messageType, SubscriptionClient subscriptionClient, IAsyncDocumentSession session)
-        {
-            var subscriptionDocId = Subscription.FormatId(messageType);
-
-            var subscription = await session.LoadAsync<Subscription>(subscriptionDocId).ConfigureAwait(false);
-
-            if (subscription.Subscribers.Contains(subscriptionClient))
+            using (var session = OpenAsyncSession())
             {
-                subscription.Subscribers.Remove(subscriptionClient);
+                foreach (var messageType in messageTypes)
+                {
+                    await subscriptionAccess.Unsubscribe(messageType, subscriptionClient, session);
+                }
             }
-            await session.SaveChangesAsync().ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IReadOnlyCollection<MessageType> messageTypes, ContextBag context)
@@ -200,5 +171,6 @@ namespace NServiceBus.Unicast.Subscriptions.RavenDB
         }
 
         IDocumentStore documentStore;
+        ISubscriptionAccess subscriptionAccess;
     }
 }


### PR DESCRIPTION
Connects to https://github.com/Particular/NServiceBus.RavenDB/issues/125

Setup two subscription access implementations, one for legacy and one for new.
Create flag to opt out of the new subscription schema for use in scale out deployment scenarios.
Add method to convert old documents to new schema on start up.
Convert unit tests to use `IndividualDocumentSubscriptionAccess`