### PR TITLE
raven session message context extension

### DIFF
--- a/src/NServiceBus.RavenDB.AcceptanceTests/App_Packages/NSB.AcceptanceTests.6.0.0-unstable1372/SelfVerification/When_running_saga_tests.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/App_Packages/NSB.AcceptanceTests.6.0.0-unstable1372/SelfVerification/When_running_saga_tests.cs
@@ -55,20 +55,22 @@
                 .ToArray();
 
             var usedNames = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
-            var offenders = 0;
+            var offenders = new HashSet<string>();
 
             Console.WriteLine("Sagas / Saga Entities with non-unique names:");
             foreach (var cls in sagas.Union(sagaEntities).Union(nestedSagaEntityParents))
             {
                 if (usedNames.Contains(cls.Name))
                 {
-                    offenders++;
+                    offenders.Add(cls.Name);
                     Console.WriteLine(cls.FullName);
                 }
                 usedNames.Add(cls.Name);
             }
 
-            Assert.AreEqual(0, offenders);
+            var failureMessage = "Non-unique names: " + string.Join("; ", offenders);
+
+            Assert.AreEqual(0, offenders.Count, failureMessage);
         }
     }
 }

--- a/src/NServiceBus.RavenDB.AcceptanceTests/NServiceBus.RavenDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/NServiceBus.RavenDB.AcceptanceTests.csproj
@@ -272,6 +272,7 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.0.0-unstable1372\Volatile\When_sending_to_non_durable_endpoint.cs" />
     <Compile Include="Config.cs" />
     <Compile Include="When_detecting_a_saga_with_multiple_corr_props.cs" />
+    <Compile Include="When_accessing_raven_session_from_handler.cs" />
     <Compile Include="When_using_a_sagafinder.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NServiceBus.RavenDB.AcceptanceTests/NServiceBus.RavenDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/NServiceBus.RavenDB.AcceptanceTests.csproj
@@ -41,6 +41,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NServiceBus.AcceptanceTesting, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.AcceptanceTesting.6.0.0-unstable1372\lib\net452\NServiceBus.AcceptanceTesting.dll</HintPath>
       <Private>True</Private>
@@ -271,8 +275,11 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.0.0-unstable1372\Versioning\When_multiple_versions_of_a_message_is_published.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.0.0-unstable1372\Volatile\When_sending_to_non_durable_endpoint.cs" />
     <Compile Include="Config.cs" />
+    <Compile Include="When_accessing_raven_session_from_handler_with_outbox.cs" />
+    <Compile Include="When_raven_session_is_provided.cs" />
+    <Compile Include="When_accessing_raven_session_with_no_saga_or_outbox.cs" />
     <Compile Include="When_detecting_a_saga_with_multiple_corr_props.cs" />
-    <Compile Include="When_accessing_raven_session_from_handler.cs" />
+    <Compile Include="When_accessing_raven_session_from_handler_with_saga.cs" />
     <Compile Include="When_using_a_sagafinder.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NServiceBus.RavenDB.AcceptanceTests/When_accessing_raven_session_from_handler.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/When_accessing_raven_session_from_handler.cs
@@ -1,0 +1,77 @@
+﻿namespace NServiceBus.AcceptanceTests.ApiExtension
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.RavenDB.Persistence;
+    using NUnit.Framework;
+    using Raven.Client;
+
+    public class When_accessing_raven_session_from_handler : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task It_should_return_configured_session()
+        {
+            var context =
+                await Scenario.Define<RavenSessionTestContext>()
+                    .WithEndpoint<RavenSessionExtensions>(b => b.When((bus, c) =>
+                    {
+                        var options = new SendOptions();
+
+                        options.RouteToLocalEndpointInstance();
+
+                        return bus.Send(new RavenSessionExtensions.GenericMessage(), options);
+                    }))
+                    .Done(c => c.HandlerWasHit)
+                    .Run();
+
+            Assert.IsNotNull(context.RavenSessionFromHandler);
+        }
+
+        public class RavenSessionTestContext : ScenarioContext
+        {
+            public IAsyncDocumentSession RavenSessionFromTest { get; set; }
+            public IAsyncDocumentSession RavenSessionFromHandler { get; set; }
+            public bool HandlerWasHit { get; set; }
+        }
+
+        public class RavenSessionExtensions : EndpointConfigurationBuilder
+        {
+            public RavenSessionExtensions()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class SagaData : IContainSagaData
+            {
+                public Guid Id { get; set; }
+                public string Originator { get; set; }
+                public string OriginalMessageId { get; set; }
+            }
+
+            public class GenericSaga : Saga<SagaData>, IAmStartedByMessages<GenericMessage>
+            {
+                public RavenSessionTestContext TestContext { get; set; }
+
+                public Task Handle(GenericMessage message, IMessageHandlerContext context)
+                {
+                    TestContext.RavenSessionFromHandler = context.GetRavenSession();
+                    TestContext.HandlerWasHit = true;
+                    return Task.FromResult(0);
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+                {
+                    mapper.ConfigureMapping<GenericMessage>(m => m.Id).ToSaga(s => s.Id);
+                }
+            }
+
+            [Serializable]
+            public class GenericMessage : IMessage
+            {
+                public Guid Id { get; set; }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB.AcceptanceTests/When_accessing_raven_session_from_handler_with_outbox.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/When_accessing_raven_session_from_handler_with_outbox.cs
@@ -1,0 +1,70 @@
+﻿namespace NServiceBus.AcceptanceTests.ApiExtension
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Configuration.AdvanceExtensibility;
+    using NServiceBus.RavenDB.Persistence;
+    using NUnit.Framework;
+    using Raven.Client;
+
+    public class When_accessing_raven_session_from_handler_with_outbox : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task It_should_return_configured_session()
+        {
+            var context =
+                await Scenario.Define<RavenSessionTestContext>()
+                    .WithEndpoint<RavenSessionExtensions>(b => b.When((bus, c) =>
+                    {
+                        var options = new SendOptions();
+
+                        options.RouteToLocalEndpointInstance();
+
+                        return bus.Send(new RavenSessionExtensions.GenericMessage(), options);
+                    }))
+                    .Done(c => c.HandlerWasHit)
+                    .Run();
+
+            Assert.IsNotNull(context.RavenSessionFromHandler);
+        }
+
+        public class RavenSessionTestContext : ScenarioContext
+        {
+            public IAsyncDocumentSession RavenSessionFromTest { get; set; }
+            public IAsyncDocumentSession RavenSessionFromHandler { get; set; }
+            public bool HandlerWasHit { get; set; }
+        }
+
+        public class RavenSessionExtensions : EndpointConfigurationBuilder
+        {
+            public RavenSessionExtensions()
+            {
+                EndpointSetup<DefaultServer>((config, context) =>
+                {
+                    config.GetSettings().Set("DisableOutboxTransportCheck", true);
+                    config.EnableOutbox();
+                });
+            }
+
+            public class GenericMessageHandler : IHandleMessages<GenericMessage>
+            {
+                public RavenSessionTestContext TestContext { get; set; }
+
+                public Task Handle(GenericMessage message, IMessageHandlerContext context)
+                {
+                    TestContext.RavenSessionFromHandler = context.GetRavenSession();
+                    TestContext.HandlerWasHit = true;
+                    return Task.FromResult(0);
+                }
+            }
+
+            [Serializable]
+            public class GenericMessage : IMessage
+            {
+                public Guid Id { get; set; }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB.AcceptanceTests/When_accessing_raven_session_from_handler_with_outbox.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/When_accessing_raven_session_from_handler_with_outbox.cs
@@ -16,13 +16,13 @@
         {
             var context =
                 await Scenario.Define<RavenSessionTestContext>()
-                    .WithEndpoint<RavenSessionExtensions>(b => b.When((bus, c) =>
+                    .WithEndpoint<RavenSessionExtensionsWithOutbox>(b => b.When((bus, c) =>
                     {
                         var options = new SendOptions();
 
                         options.RouteToLocalEndpointInstance();
 
-                        return bus.Send(new RavenSessionExtensions.GenericMessage(), options);
+                        return bus.Send(new RavenSessionExtensionsWithOutbox.GenericMessage(), options);
                     }))
                     .Done(c => c.HandlerWasHit)
                     .Run();
@@ -37,9 +37,9 @@
             public bool HandlerWasHit { get; set; }
         }
 
-        public class RavenSessionExtensions : EndpointConfigurationBuilder
+        public class RavenSessionExtensionsWithOutbox : EndpointConfigurationBuilder
         {
-            public RavenSessionExtensions()
+            public RavenSessionExtensionsWithOutbox()
             {
                 EndpointSetup<DefaultServer>((config, context) =>
                 {

--- a/src/NServiceBus.RavenDB.AcceptanceTests/When_accessing_raven_session_from_handler_with_saga.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/When_accessing_raven_session_from_handler_with_saga.cs
@@ -43,9 +43,9 @@
                 EndpointSetup<DefaultServer>();
             }
 
-            public class SagaData : IContainSagaData
+            public class SessionExtensionSagaData : IContainSagaData
             {
-                public SagaData()
+                public SessionExtensionSagaData()
                 {
                     if (Id.ToString() == new Guid().ToString())
                     {
@@ -58,7 +58,7 @@
                 public string OriginalMessageId { get; set; }
             }
 
-            public class GenericSaga : Saga<SagaData>, IAmStartedByMessages<GenericMessage>
+            public class SessionExtensionGenericSaga : Saga<SessionExtensionSagaData>, IAmStartedByMessages<GenericMessage>
             {
                 public RavenSessionTestContext TestContext { get; set; }
 
@@ -69,7 +69,7 @@
                     return Task.FromResult(0);
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SessionExtensionSagaData> mapper)
                 {
                     mapper.ConfigureMapping<GenericMessage>(m => m.Id).ToSaga(s => s.Id);
                 }

--- a/src/NServiceBus.RavenDB.AcceptanceTests/When_accessing_raven_session_from_handler_with_saga.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/When_accessing_raven_session_from_handler_with_saga.cs
@@ -8,7 +8,7 @@
     using NUnit.Framework;
     using Raven.Client;
 
-    public class When_accessing_raven_session_from_handler : NServiceBusAcceptanceTest
+    public class When_accessing_raven_session_from_handler_with_saga : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task It_should_return_configured_session()
@@ -45,6 +45,14 @@
 
             public class SagaData : IContainSagaData
             {
+                public SagaData()
+                {
+                    if (Id.ToString() == new Guid().ToString())
+                    {
+                        Id = Guid.NewGuid();
+                    }
+                }
+
                 public Guid Id { get; set; }
                 public string Originator { get; set; }
                 public string OriginalMessageId { get; set; }

--- a/src/NServiceBus.RavenDB.AcceptanceTests/When_accessing_raven_session_with_no_saga_or_outbox.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/When_accessing_raven_session_with_no_saga_or_outbox.cs
@@ -1,0 +1,76 @@
+﻿namespace NServiceBus.AcceptanceTests.ApiExtension
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.RavenDB.Persistence;
+    using NUnit.Framework;
+    using Raven.Client;
+
+    public class When_accessing_raven_session_with_no_saga_or_outbox : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task It_should_throw_an_exception()
+        {
+            var context =
+                await Scenario.Define<RavenSessionTestContext>()
+                    .WithEndpoint<RavenSessionExtensions>(b => b.When((bus, c) =>
+                    {
+                        var options = new SendOptions();
+
+                        options.RouteToLocalEndpointInstance();
+
+                        return bus.Send(new RavenSessionExtensions.GenericMessage(), options);
+                    }))
+                    .Done(c => c.HandlerWasHit)
+                    .Run();
+
+            Assert.IsNull(context.RavenSessionFromHandler);
+            Assert.IsTrue(context.Exception.Message.Contains("saga"));
+            Assert.IsTrue(context.Exception.Message.Contains("outbox"));
+        }
+
+        public class RavenSessionTestContext : ScenarioContext
+        {
+            public IAsyncDocumentSession RavenSessionFromTest { get; set; }
+            public IAsyncDocumentSession RavenSessionFromHandler { get; set; }
+            public bool HandlerWasHit { get; set; }
+            public Exception Exception { get; set; }
+        }
+
+        public class RavenSessionExtensions : EndpointConfigurationBuilder
+        {
+            public RavenSessionExtensions()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class GenericMessageHandler : IHandleMessages<GenericMessage>
+            {
+                public RavenSessionTestContext TestContext { get; set; }
+
+                public Task Handle(GenericMessage message, IMessageHandlerContext context)
+                {
+                    try
+                    {
+                        TestContext.RavenSessionFromHandler = context.GetRavenSession();
+                    }
+                    catch (Exception e)
+                    {
+                        TestContext.Exception = e;
+                    }
+                    TestContext.HandlerWasHit = true;
+                    return Task.FromResult(0);
+                }
+            }
+
+
+            [Serializable]
+            public class GenericMessage : IMessage
+            {
+                public Guid Id { get; set; }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB.AcceptanceTests/When_accessing_raven_session_with_no_saga_or_outbox.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/When_accessing_raven_session_with_no_saga_or_outbox.cs
@@ -4,7 +4,6 @@
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
-    using NServiceBus.RavenDB.Persistence;
     using NUnit.Framework;
     using Raven.Client;
 
@@ -27,8 +26,8 @@
                     .Run();
 
             Assert.IsNull(context.RavenSessionFromHandler);
-            Assert.IsTrue(context.Exception.Message.Contains("saga"));
-            Assert.IsTrue(context.Exception.Message.Contains("outbox"));
+            Assert.IsTrue(context.Exception.Message.ToLower().Contains("saga"), "The exception message should alert the user about necessary features.");
+            Assert.IsTrue(context.Exception.Message.ToLower().Contains("outbox"), "The exception message should alert the user about necessary features.");
         }
 
         public class RavenSessionTestContext : ScenarioContext

--- a/src/NServiceBus.RavenDB.AcceptanceTests/When_raven_session_is_provided.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/When_raven_session_is_provided.cs
@@ -22,13 +22,13 @@
                 {
                     testContext.RavenSessionFromTest = session;
                 })
-                    .WithEndpoint<RavenSessionExtensions>(b => b.When((bus, c) =>
+                    .WithEndpoint<SharedRavenSessionExtensions>(b => b.When((bus, c) =>
                     {
                         var options = new SendOptions();
 
                         options.RouteToLocalEndpointInstance();
 
-                        return bus.Send(new RavenSessionExtensions.GenericMessage(), options);
+                        return bus.Send(new SharedRavenSessionExtensions.GenericMessage(), options);
                     }))
                     .Done(c => c.HandlerWasHit)
                     .Run();
@@ -43,9 +43,9 @@
             public bool HandlerWasHit { get; set; }
         }
 
-        public class RavenSessionExtensions : EndpointConfigurationBuilder
+        public class SharedRavenSessionExtensions : EndpointConfigurationBuilder
         {
-            public RavenSessionExtensions()
+            public SharedRavenSessionExtensions()
             {
                 EndpointSetup<DefaultServer>((config, context) =>
                 {
@@ -54,14 +54,14 @@
                 });
             }
 
-            public class SagaData : IContainSagaData
+            public class SharedSessionSagaData : IContainSagaData
             {
                 public Guid Id { get; set; }
                 public string Originator { get; set; }
                 public string OriginalMessageId { get; set; }
             }
 
-            public class GenericSaga : Saga<SagaData>, IAmStartedByMessages<GenericMessage>
+            public class SharedSessionGenericSaga : Saga<SharedSessionSagaData>, IAmStartedByMessages<GenericMessage>
             {
                 public RavenSessionTestContext TestContext { get; set; }
 
@@ -72,7 +72,7 @@
                     return Task.FromResult(0);
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SharedSessionSagaData> mapper)
                 {
                     mapper.ConfigureMapping<GenericMessage>(m => m.Id).ToSaga(s => s.Id);
                 }

--- a/src/NServiceBus.RavenDB.AcceptanceTests/When_raven_session_is_provided.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/When_raven_session_is_provided.cs
@@ -1,0 +1,88 @@
+﻿namespace NServiceBus.AcceptanceTests.ApiExtension
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using Moq;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Persistence;
+    using NServiceBus.RavenDB.Persistence;
+    using NUnit.Framework;
+    using Raven.Client;
+
+    public class When_raven_session_is_provided : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task It_should_return_configured_session()
+        {
+            var session = Mock.Of<IAsyncDocumentSession>();
+
+            var context =
+                await Scenario.Define<RavenSessionTestContext>(testContext =>
+                {
+                    testContext.RavenSessionFromTest = session;
+                })
+                    .WithEndpoint<RavenSessionExtensions>(b => b.When((bus, c) =>
+                    {
+                        var options = new SendOptions();
+
+                        options.RouteToLocalEndpointInstance();
+
+                        return bus.Send(new RavenSessionExtensions.GenericMessage(), options);
+                    }))
+                    .Done(c => c.HandlerWasHit)
+                    .Run();
+
+            Assert.AreSame(session, context.RavenSessionFromHandler);
+        }
+
+        public class RavenSessionTestContext : ScenarioContext
+        {
+            public IAsyncDocumentSession RavenSessionFromTest { get; set; }
+            public IAsyncDocumentSession RavenSessionFromHandler { get; set; }
+            public bool HandlerWasHit { get; set; }
+        }
+
+        public class RavenSessionExtensions : EndpointConfigurationBuilder
+        {
+            public RavenSessionExtensions()
+            {
+                EndpointSetup<DefaultServer>((config, context) =>
+                {
+                    var scenarioContext = context.ScenarioContext as RavenSessionTestContext;
+                    config.UsePersistence<RavenDBPersistence>().UseSharedAsyncSession(() => scenarioContext.RavenSessionFromTest);
+                });
+            }
+
+            public class SagaData : IContainSagaData
+            {
+                public Guid Id { get; set; }
+                public string Originator { get; set; }
+                public string OriginalMessageId { get; set; }
+            }
+
+            public class GenericSaga : Saga<SagaData>, IAmStartedByMessages<GenericMessage>
+            {
+                public RavenSessionTestContext TestContext { get; set; }
+
+                public Task Handle(GenericMessage message, IMessageHandlerContext context)
+                {
+                    TestContext.RavenSessionFromHandler = context.GetRavenSession();
+                    TestContext.HandlerWasHit = true;
+                    return Task.FromResult(0);
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+                {
+                    mapper.ConfigureMapping<GenericMessage>(m => m.Id).ToSaga(s => s.Id);
+                }
+            }
+
+            [Serializable]
+            public class GenericMessage : IMessage
+            {
+                public Guid Id { get; set; }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB.AcceptanceTests/packages.config
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Moq" version="4.2.1510.2205" targetFramework="net452" />
   <package id="NServiceBus" version="6.0.0-unstable1378" targetFramework="net452" />
   <package id="NServiceBus.AcceptanceTesting" version="6.0.0-unstable1372" targetFramework="net452" />
   <package id="NServiceBus.AcceptanceTests.Sources" version="6.0.0-unstable1372" targetFramework="net452" />

--- a/src/NServiceBus.RavenDB.Tests/Persistence/DocumentStoreExtensionsForVoron.cs
+++ b/src/NServiceBus.RavenDB.Tests/Persistence/DocumentStoreExtensionsForVoron.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using Raven.Abstractions.Data;
     using Raven.Client.Document;
 
@@ -38,7 +39,13 @@
 
             public void Dispose()
             {
-                store.DatabaseCommands.GlobalAdmin.DeleteDatabase(dbName, hardDelete: true);
+                // Task.Delay is being used to allow raven time to unlock the database 
+                // Task.Run is being used to take the cleanup of the database out of the context of the test runner, as the test should not fail if cleanup fails.
+                Task.Run(() =>
+                {
+                    Task.Delay(500);
+                    store.DatabaseCommands.GlobalAdmin.DeleteDatabase(dbName, hardDelete: true);
+                });
             }
         }
     }

--- a/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
+++ b/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
@@ -107,6 +107,7 @@
     <Compile Include="SagaPersister\RavenDbSagaStorage.cs" />
     <Compile Include="SagaPersister\SagaPersister.cs" />
     <Compile Include="SagaPersister\SagaUniqueIdentity.cs" />
+    <Compile Include="SessionManagement\RavenSessionExtension.cs" />
     <Compile Include="SessionManagement\SynchronizedStorage.cs" />
     <Compile Include="Subscriptions\MessageTypeConverter.cs" />
     <Compile Include="Subscriptions\RavenDbSubscriptionSettingsExtensions.cs" />

--- a/src/NServiceBus.RavenDB/SessionManagement/RavenSessionExtension.cs
+++ b/src/NServiceBus.RavenDB/SessionManagement/RavenSessionExtension.cs
@@ -1,6 +1,6 @@
 ﻿using Raven.Client;
 
-namespace NServiceBus.RavenDB.Persistence
+namespace NServiceBus
 {
     using System;
 
@@ -26,7 +26,10 @@ namespace NServiceBus.RavenDB.Persistence
             context.Extensions.TryGet(out session);
             if (session == null)
             {
-                throw new Exception("Could not retrieve a RavenDB session. Please ensure that you are using a saga or have enabled outbox.");
+                throw new Exception(
+                    @"GetRavenSession() allows retrieval of the shared Raven IAsyncDocumentSession 
+being used by NServiceBus so that additional Raven operations can be completed in the same transactional context as NServiceBus Sagas and Outbox features. 
+Because the Saga and Outbox features are not currently in use, it was not possible to retrieve a RavenDB session.");
             }
             return session;
         }

--- a/src/NServiceBus.RavenDB/SessionManagement/RavenSessionExtension.cs
+++ b/src/NServiceBus.RavenDB/SessionManagement/RavenSessionExtension.cs
@@ -2,6 +2,8 @@
 
 namespace NServiceBus.RavenDB.Persistence
 {
+    using System;
+
     /// <summary>
     /// Extensions, to the message handler context, to manage RavenDB session.
     /// </summary>
@@ -14,7 +16,19 @@ namespace NServiceBus.RavenDB.Persistence
         /// <returns></returns>
         public static IAsyncDocumentSession GetRavenSession(this IMessageHandlerContext context)
         {
-            return context.Extensions.Get<IAsyncDocumentSession>();
+            Func<IAsyncDocumentSession> sessionFunction;
+            context.Extensions.TryGet(out sessionFunction);
+            if (sessionFunction != null)
+            {
+                return sessionFunction();
+            }
+            IAsyncDocumentSession session;
+            context.Extensions.TryGet(out session);
+            if (session == null)
+            {
+                throw new Exception("Could not retrieve a RavenDB session. Please ensure that you are using a saga or have enabled outbox.");
+            }
+            return session;
         }
     }
 }

--- a/src/NServiceBus.RavenDB/SessionManagement/RavenSessionExtension.cs
+++ b/src/NServiceBus.RavenDB/SessionManagement/RavenSessionExtension.cs
@@ -1,0 +1,20 @@
+﻿using Raven.Client;
+
+namespace NServiceBus.RavenDB.Persistence
+{
+    /// <summary>
+    /// Extensions, to the message handler context, to manage RavenDB session.
+    /// </summary>
+    public static class RavenSessionExtension
+    {
+        /// <summary>
+        /// Gets the current RavenDB session.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <returns></returns>
+        public static IAsyncDocumentSession GetRavenSession(this IMessageHandlerContext context)
+        {
+            return context.Extensions.Get<IAsyncDocumentSession>();
+        }
+    }
+}


### PR DESCRIPTION
Connects to #113
Adds the ability to retrieve from the current message context the RavenDB session.
Misses tests.
@colin-higgins this is actually missing the `set` step, what it is not clear to me is if [this behavior](https://github.com/Particular/NServiceBus.RavenDB/blob/GetRavenSession-message-context-extension/src/NServiceBus.RavenDB/SessionManagement/ProvidedAsyncSessionBehavior.cs#L15) is enough to set the current session