### PR TITLE
Move persistence definition to core namespace

### DIFF
--- a/src/NServiceBus.RavenDB/RavenDBPersistence.cs
+++ b/src/NServiceBus.RavenDB/RavenDBPersistence.cs
@@ -1,6 +1,7 @@
-﻿namespace NServiceBus.Persistence
+﻿namespace NServiceBus
 {
     using NServiceBus.Features;
+    using NServiceBus.Persistence;
     using NServiceBus.RavenDB;
     using NServiceBus.RavenDB.Outbox;
     using NServiceBus.RavenDB.SessionManagement;


### PR DESCRIPTION
@DavidBoike @mauroservienti @kbaley 

Please review. It follows what NHibernate does as well.