### PR TITLE
[WIP] RavenDB 3.1.1 Hotfix

### DIFF
--- a/src/NServiceBus.RavenDB.AcceptanceTests/Config.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/Config.cs
@@ -28,7 +28,7 @@ public class ConfigureRavenDBPersistence
         var persistenceExtensions = config.UsePersistence<RavenDBPersistence>()
             .DoNotSetupDatabasePermissions()
             .SetDefaultDocumentStore(documentStore)
-            .SetTransactionRecoveryStorageBasePath("%LOCALAPPDATA%");
+            .SetTransactionRecoveryStorageBasePath(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData));
 
         settings.Set(DefaultPersistenceExtensionsKey, persistenceExtensions);
 

--- a/src/NServiceBus.RavenDB.AcceptanceTests/Config.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/Config.cs
@@ -27,7 +27,8 @@ public class ConfigureRavenDBPersistence
 
         var persistenceExtensions = config.UsePersistence<RavenDBPersistence>()
             .DoNotSetupDatabasePermissions()
-            .SetDefaultDocumentStore(documentStore);
+            .SetDefaultDocumentStore(documentStore)
+            .SetTransactionRecoveryStorageBasePath("%LOCALAPPDATA%");
 
         settings.Set(DefaultPersistenceExtensionsKey, persistenceExtensions);
 

--- a/src/NServiceBus.RavenDB.Tests/Timeouts/Should_not_skip_timeouts.cs
+++ b/src/NServiceBus.RavenDB.Tests/Timeouts/Should_not_skip_timeouts.cs
@@ -6,11 +6,11 @@ namespace NServiceBus.RavenDB.Tests.Timeouts
 {
     using System.Diagnostics;
     using System.Threading;
+    using NServiceBus.RavenDB.Shutdown;
     using NUnit.Framework;
     using Raven.Client;
     using Raven.Client.Document;
     using TimeoutData = Timeout.Core.TimeoutData;
-    using Timeout = TimeoutPersisters.RavenDB.TimeoutData;
     using TimeoutPersisters.RavenDB;
 
     [TestFixture]
@@ -29,7 +29,7 @@ namespace NServiceBus.RavenDB.Tests.Timeouts
             {
                 new TimeoutsIndex().Execute(documentStore);
 
-                var persister = new TimeoutPersister
+                var persister = new TimeoutPersister(new ShutdownDelegateRegistry())
                             {
                                 DocumentStore = documentStore,
                                 EndpointName = "foo",
@@ -124,8 +124,8 @@ namespace NServiceBus.RavenDB.Tests.Timeouts
             {
                 new TimeoutsIndex().Execute(documentStore);
 
-                var persister = new TimeoutPersister
-                                {
+                var persister = new TimeoutPersister(new ShutdownDelegateRegistry())
+                {
                                     DocumentStore = documentStore,
                                     EndpointName = "foo",
                                     TriggerCleanupEvery = TimeSpan.FromDays(1), // Make sure cleanup doesn't run automatically
@@ -169,8 +169,8 @@ namespace NServiceBus.RavenDB.Tests.Timeouts
                                    DefaultDatabase = db,
                                }.Initialize())
                                {
-                                   var persister2 = new TimeoutPersister
-                                                    {
+                                   var persister2 = new TimeoutPersister(new ShutdownDelegateRegistry())
+                                   {
                                                         DocumentStore = store,
                                                         EndpointName = "bar",
                                                     };

--- a/src/NServiceBus.RavenDB.Tests/Timeouts/When_fetching_timeouts_from_storage.cs
+++ b/src/NServiceBus.RavenDB.Tests/Timeouts/When_fetching_timeouts_from_storage.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using NServiceBus.RavenDB.Shutdown;
     using NUnit.Framework;
     using Support;
     using TimeoutPersisters.RavenDB;
@@ -15,8 +16,8 @@
         {
             new TimeoutsIndex().Execute(store);
 
-            var persister = new TimeoutPersister
-                            {
+            var persister = new TimeoutPersister(new ShutdownDelegateRegistry())
+            {
                                 DocumentStore = store,
                                 EndpointName = "MyTestEndpoint",
                             };
@@ -47,7 +48,7 @@
         {
             new TimeoutsIndex().Execute(store);
 
-            var persister = new TimeoutPersister
+            var persister = new TimeoutPersister(new ShutdownDelegateRegistry())
             {
                 DocumentStore = store,
                 EndpointName = "MyTestEndpoint",

--- a/src/NServiceBus.RavenDB.Tests/Timeouts/When_removing_timeouts_from_the_storage.cs
+++ b/src/NServiceBus.RavenDB.Tests/Timeouts/When_removing_timeouts_from_the_storage.cs
@@ -6,6 +6,7 @@ namespace NServiceBus.RavenDB.Tests.Timeouts
     using System.Linq;
     using System.Threading.Tasks;
     using System.Transactions;
+    using NServiceBus.RavenDB.Shutdown;
     using NUnit.Framework;
     using Support;
     using TimeoutPersisters.RavenDB;
@@ -22,7 +23,7 @@ namespace NServiceBus.RavenDB.Tests.Timeouts
         {
             store = NewDocumentStore(false, "esent");
             new TimeoutsIndex().Execute(store);
-            timeoutPersister = new TimeoutPersister
+            timeoutPersister = new TimeoutPersister(new ShutdownDelegateRegistry())
             {
                 DocumentStore = store,
                 EndpointName = "MyTestEndpoint",

--- a/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
@@ -53,40 +53,66 @@
                 return;
             }
 
-            // Source: https://github.com/ravendb/ravendb/blob/f56963f23f54b5535eba4f043fb84d5145b11b1d/Raven.Client.Lightweight/Document/DocumentStore.cs#L129
-            var ravenDefaultResourceManagerId = new Guid("e749baa6-6f76-4eef-a069-40a4378954f8");
-
-            if (store.ResourceManagerId != ravenDefaultResourceManagerId)
-            {
-                Logger.Warn("Overriding user-specified documentStore.ResourceManagerId. It's no longer necessary to set this value while using NServiceBus.RavenDB persistence. Consider using busConfiguration.CustomizeDocumentStore(Action<IDocumentStore customize) if this is absolutely necessary, but it is not recommended.");
-            }
-            if (!(store.TransactionRecoveryStorage is VolatileOnlyTransactionRecoveryStorage))
-            {
-                Logger.Warn("Overriding user-specified documentStore.TransactionRecoveryStorage. It's no longer necessary to set this value while using NServiceBus.RavenDB persistence. Consider using busConfiguration.CustomizeDocumentStore(Action<IDocumentStore customize) if this is absolutely necessary, but it is not recommended.");
-            }
-
-            var resourceManagerId = settings.Get<string>("NServiceBus.LocalAddress") + "-" + settings.Get<string>("EndpointVersion");
-            store.ResourceManagerId = DeterministicGuidBuilder(resourceManagerId);
-
-            string path = $@"%LOCALAPPDATA%\NServiceBus.RavenDB\{store.ResourceManagerId}";
-            store.TransactionRecoveryStorage = new LocalDirectoryTransactionRecoveryStorage(path);
-
             bool suppressDistributedTransactions;
             if (settings.TryGet("Transactions.SuppressDistributedTransactions", out suppressDistributedTransactions) && suppressDistributedTransactions)
             {
                 store.EnlistInDistributedTransactions = false;
             }
+            else
+            {
+                // Source: https://github.com/ravendb/ravendb/blob/f56963f23f54b5535eba4f043fb84d5145b11b1d/Raven.Client.Lightweight/Document/DocumentStore.cs#L129
+                var ravenDefaultResourceManagerId = new Guid("e749baa6-6f76-4eef-a069-40a4378954f8");
+
+
+                if (store.JsonRequestFactory != null) // code for "has the DocStore been Initialized yet"
+                {
+                    // If the DocumentStore has already been initialized, that means transaction recovery has already
+                    // been run and the TransactionRecoveryStorage cannot be safely swapped with our safe values.
+                    // Only (known) reason to do this would be if customer wants to share the DocumentStore with
+                    // a wider application's persistence needs and must initialize it before NServiceBus is invoked.
+                    // Therefore, we will check to make sure ResourceManagerId and TransactionRecoveryStorage are
+                    // acceptable and throw if they are not.
+
+                    var dtcSettingsAcceptable = store.ResourceManagerId != Guid.Empty
+                                                && store.ResourceManagerId != ravenDefaultResourceManagerId
+                                                && store.TransactionRecoveryStorage is LocalDirectoryTransactionRecoveryStorage;
+
+                    if (!dtcSettingsAcceptable)
+                    {
+                        throw new InvalidOperationException("RavenDB Persistence DocumentStore has already been initialized without safe DTC settings which can lead to data loss. Either allow NServiceBus to initialize the DocumentStore instance or refer to documentation to set up safe DTC settings.");
+                    }
+                }
+                else
+                {
+                    if (store.ResourceManagerId != ravenDefaultResourceManagerId)
+                    {
+                        Logger.Warn("Overriding user-specified documentStore.ResourceManagerId. It's no longer necessary to set this value while using NServiceBus.RavenDB persistence. Consider using busConfiguration.CustomizeDocumentStore(Action<IDocumentStore customize) if this is absolutely necessary, but it is not recommended.");
+                    }
+                    if (!(store.TransactionRecoveryStorage is VolatileOnlyTransactionRecoveryStorage))
+                    {
+                        Logger.Warn("Overriding user-specified documentStore.TransactionRecoveryStorage. It's no longer necessary to set this value while using NServiceBus.RavenDB persistence. Consider using busConfiguration.CustomizeDocumentStore(Action<IDocumentStore customize) if this is absolutely necessary, but it is not recommended.");
+                    }
+
+                    var resourceManagerId = settings.Get<string>("NServiceBus.LocalAddress") + "-" + settings.Get<string>("EndpointVersion");
+                    store.ResourceManagerId = DeterministicGuidBuilder(resourceManagerId);
+
+                    store.TransactionRecoveryStorage = RavenTransactionRecoveryStorageCreator.Create(docStore, settings);
+                }
+            }
         }
 
         static Guid DeterministicGuidBuilder(string input)
         {
-            // use MD5 hash to get a 16-byte hash of the string
+            // use SHA1 hash to get a hash of the string - SHA1 to avoid FIPS troubles
             using (var provider = new SHA1CryptoServiceProvider())
             {
                 var inputBytes = Encoding.UTF8.GetBytes(input);
                 var hashBytes = provider.ComputeHash(inputBytes);
+
+                // Guids only need 16 bytes. SHA1 hashes are 20 bytes
                 var first16HashBytes = new byte[16];
                 Array.Copy(hashBytes, first16HashBytes, 16);
+
                 // generate a guid from the hash:
                 return new Guid(first16HashBytes);
             }

--- a/src/NServiceBus.RavenDB/Internal/RavenDbPersistenceSettingsExtensions.cs
+++ b/src/NServiceBus.RavenDB/Internal/RavenDbPersistenceSettingsExtensions.cs
@@ -11,6 +11,8 @@
     /// </summary>
     public static class RavenDbPersistenceSettingsExtensions
     {
+        internal const string TransactionRecoveryStorageBasePathKey = "RavenDB/TransactionRecoveryStorage/BasePath";
+
         /// <summary>
         /// Run a delegate against the RavenDB DocumentStore used by NServiceBus before NServiceBus calls Initialize on it.
         /// </summary>
@@ -20,6 +22,18 @@
         public static PersistenceExtentions<RavenDBPersistence> CustomizeDocumentStore(this PersistenceExtentions<RavenDBPersistence> cfg, Action<IDocumentStore> customize)
         {
             DocumentStoreManager.SetCustomizeDocumentStoreDelegate(cfg.GetSettings(), customize);
+            return cfg;
+        }
+
+        /// <summary>
+        /// Specify a location where RavenDB can store transaction recovery information. The application must have write permissions to the directory.
+        /// </summary>
+        /// <param name="cfg"></param>
+        /// <param name="basePath">A directory where the application will have read/write permisisons.</param>
+        /// <returns></returns>
+        public static PersistenceExtentions<RavenDBPersistence> SetTransactionRecoveryStorageBasePath(this PersistenceExtentions<RavenDBPersistence> cfg, string basePath)
+        {
+            cfg.GetSettings().Set(TransactionRecoveryStorageBasePathKey, basePath);
             return cfg;
         }
     }

--- a/src/NServiceBus.RavenDB/Internal/RavenTransactionRecoveryStorageCreator.cs
+++ b/src/NServiceBus.RavenDB/Internal/RavenTransactionRecoveryStorageCreator.cs
@@ -27,6 +27,10 @@
                 var programDataPathForException = Environment.ExpandEnvironmentVariables("%PROGRAMDATA%");
                 throw new InvalidOperationException($"Unable to store RavenDB transaction recovery storage information. Specify a writeable directory using the .SetTransactionRecoveryStorageBasePath(basePath) option. `{programDataPathForException}` may be a good candidate. The same path can be shared by multiple endpoints.");
             }
+            if (!string.Equals(Environment.ExpandEnvironmentVariables(settingsBasePath), settingsBasePath, StringComparison.InvariantCultureIgnoreCase))
+            {
+                throw new InvalidOperationException($"RavenDB transaction recovery storage path `{settingsBasePath}` cannot contain environment variables because any change to an environment variable might change the path, which could result in data loss.");
+            }
 
             var suffixPath = Path.Combine("NServiceBus.RavenDB", docStore.ResourceManagerId.ToString());
             const string commonErrorMsg = "Unable to access RavenDB transaction recovery storage specified by `.SetTransactionRecoveryStorageBasePath(string basePath)`.";

--- a/src/NServiceBus.RavenDB/Internal/RavenTransactionRecoveryStorageCreator.cs
+++ b/src/NServiceBus.RavenDB/Internal/RavenTransactionRecoveryStorageCreator.cs
@@ -1,0 +1,82 @@
+﻿namespace NServiceBus.RavenDB.Internal
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Configuration;
+    using System.IO;
+    using NServiceBus.Logging;
+    using NServiceBus.Settings;
+    using Raven.Client;
+    using Raven.Client.Document;
+    using Raven.Client.Document.DTC;
+
+    class RavenTransactionRecoveryStorageCreator
+    {
+        readonly string suffixPath;
+
+        static readonly ILog logger = LogManager.GetLogger<RavenTransactionRecoveryStorageCreator>();
+
+        private RavenTransactionRecoveryStorageCreator(IDocumentStore store)
+        {
+            var docStore = store as DocumentStore;
+            if (docStore == null)
+            {
+                throw new InvalidOperationException("Cannot create transaction recovery storage for anything but a full DocumentStore instance.");
+            }
+
+            this.suffixPath = Path.Combine("NServiceBus.RavenDB", docStore.ResourceManagerId.ToString());
+        }
+
+        public static ITransactionRecoveryStorage Create(IDocumentStore store, ReadOnlySettings settings)
+        {
+            var creator = new RavenTransactionRecoveryStorageCreator(store);
+            foreach (var location in creator.TryToCreateFromConfiguredLocations(settings))
+            {
+                if (location != null)
+                    return location;
+            }
+            
+            throw new InvalidOperationException($"Unable to store RavenDB transaction recovery storage information. Specify a writeable directory using the `{RavenDbPersistenceSettingsExtensions.TransactionRecoveryStorageBasePathKey}` appSetting or .SetTransactionRecoveryStorageBasePath(basePath) option. `%LOCALAPPDATA%`, `%APPDATA%`, or `%PROGRAMDATA%` are good candidates. The same path can be shared by multiple endpoints.");
+        }
+
+        private IEnumerable<LocalDirectoryTransactionRecoveryStorage> TryToCreateFromConfiguredLocations(ReadOnlySettings settings)
+        {
+            var settingsBasePath = settings.GetOrDefault<string>(RavenDbPersistenceSettingsExtensions.TransactionRecoveryStorageBasePathKey);
+            yield return TryCreate(settingsBasePath,
+                "Unable to access RavenDB transaction recovery storage specified by `.SetTransactionRecoveryStorageBasePath(string basePath)`.");
+
+            var configBasePath = ConfigurationManager.AppSettings[RavenDbPersistenceSettingsExtensions.TransactionRecoveryStorageBasePathKey];
+            yield return TryCreate(configBasePath,
+                $"Unable to access RavenDB transaction recovery storage specified in appSetting `{RavenDbPersistenceSettingsExtensions.TransactionRecoveryStorageBasePathKey}`.");
+        }
+
+        private LocalDirectoryTransactionRecoveryStorage TryCreate(string basePath, string errorMessage)
+        {
+            if (basePath == null)
+            {
+                return null;
+            }
+
+            var fullPath = Path.Combine(Environment.ExpandEnvironmentVariables(basePath), this.suffixPath);
+
+            LocalDirectoryTransactionRecoveryStorage storage;
+
+            try
+            {
+                storage = new LocalDirectoryTransactionRecoveryStorage(fullPath);
+            }
+            catch (UnauthorizedAccessException uax)
+            {
+                throw new InvalidOperationException($"{errorMessage} Access to `{basePath}`is denied.", uax);
+            }
+            catch (Exception x)
+            {
+                throw new InvalidOperationException(errorMessage, x);
+            }
+
+            logger.Info($"RavenDB persistence using DTC transaction recovery storage located at `{fullPath}`.");
+
+            return storage;
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB/Internal/RavenTransactionRecoveryStorageCreator.cs
+++ b/src/NServiceBus.RavenDB/Internal/RavenTransactionRecoveryStorageCreator.cs
@@ -1,8 +1,6 @@
 ﻿namespace NServiceBus.RavenDB.Internal
 {
     using System;
-    using System.Collections.Generic;
-    using System.Configuration;
     using System.IO;
     using NServiceBus.Logging;
     using NServiceBus.Settings;
@@ -10,13 +8,11 @@
     using Raven.Client.Document;
     using Raven.Client.Document.DTC;
 
-    class RavenTransactionRecoveryStorageCreator
+    static class RavenTransactionRecoveryStorageCreator
     {
-        readonly string suffixPath;
+        private static readonly ILog logger = LogManager.GetLogger(typeof(RavenTransactionRecoveryStorageCreator));
 
-        static readonly ILog logger = LogManager.GetLogger<RavenTransactionRecoveryStorageCreator>();
-
-        private RavenTransactionRecoveryStorageCreator(IDocumentStore store)
+        public static ITransactionRecoveryStorage Create(IDocumentStore store, ReadOnlySettings settings)
         {
             var docStore = store as DocumentStore;
             if (docStore == null)
@@ -24,59 +20,33 @@
                 throw new InvalidOperationException("Cannot create transaction recovery storage for anything but a full DocumentStore instance.");
             }
 
-            this.suffixPath = Path.Combine("NServiceBus.RavenDB", docStore.ResourceManagerId.ToString());
-        }
-
-        public static ITransactionRecoveryStorage Create(IDocumentStore store, ReadOnlySettings settings)
-        {
-            var creator = new RavenTransactionRecoveryStorageCreator(store);
-            foreach (var location in creator.TryToCreateFromConfiguredLocations(settings))
-            {
-                if (location != null)
-                    return location;
-            }
-            
-            throw new InvalidOperationException($"Unable to store RavenDB transaction recovery storage information. Specify a writeable directory using the `{RavenDbPersistenceSettingsExtensions.TransactionRecoveryStorageBasePathKey}` appSetting or .SetTransactionRecoveryStorageBasePath(basePath) option. `%LOCALAPPDATA%`, `%APPDATA%`, or `%PROGRAMDATA%` are good candidates. The same path can be shared by multiple endpoints.");
-        }
-
-        private IEnumerable<LocalDirectoryTransactionRecoveryStorage> TryToCreateFromConfiguredLocations(ReadOnlySettings settings)
-        {
             var settingsBasePath = settings.GetOrDefault<string>(RavenDbPersistenceSettingsExtensions.TransactionRecoveryStorageBasePathKey);
-            yield return TryCreate(settingsBasePath,
-                "Unable to access RavenDB transaction recovery storage specified by `.SetTransactionRecoveryStorageBasePath(string basePath)`.");
 
-            var configBasePath = ConfigurationManager.AppSettings[RavenDbPersistenceSettingsExtensions.TransactionRecoveryStorageBasePathKey];
-            yield return TryCreate(configBasePath,
-                $"Unable to access RavenDB transaction recovery storage specified in appSetting `{RavenDbPersistenceSettingsExtensions.TransactionRecoveryStorageBasePathKey}`.");
-        }
-
-        private LocalDirectoryTransactionRecoveryStorage TryCreate(string basePath, string errorMessage)
-        {
-            if (basePath == null)
+            if (settingsBasePath == null)
             {
-                return null;
+                var programDataPathForException = Environment.ExpandEnvironmentVariables("%PROGRAMDATA%");
+                throw new InvalidOperationException($"Unable to store RavenDB transaction recovery storage information. Specify a writeable directory using the .SetTransactionRecoveryStorageBasePath(basePath) option. `{programDataPathForException}` may be a good candidate. The same path can be shared by multiple endpoints.");
             }
 
-            var fullPath = Path.Combine(Environment.ExpandEnvironmentVariables(basePath), this.suffixPath);
+            var suffixPath = Path.Combine("NServiceBus.RavenDB", docStore.ResourceManagerId.ToString());
+            const string commonErrorMsg = "Unable to access RavenDB transaction recovery storage specified by `.SetTransactionRecoveryStorageBasePath(string basePath)`.";
 
-            LocalDirectoryTransactionRecoveryStorage storage;
+            var fullPath = Path.Combine(settingsBasePath, suffixPath);
 
             try
             {
-                storage = new LocalDirectoryTransactionRecoveryStorage(fullPath);
+                var storage = new LocalDirectoryTransactionRecoveryStorage(fullPath);
+                logger.Info($"RavenDB persistence using DTC transaction recovery storage located at `{fullPath}`.");
+                return storage;
             }
             catch (UnauthorizedAccessException uax)
             {
-                throw new InvalidOperationException($"{errorMessage} Access to `{basePath}`is denied.", uax);
+                throw new InvalidOperationException($"{commonErrorMsg} Access to `{settingsBasePath}`is denied.", uax);
             }
             catch (Exception x)
             {
-                throw new InvalidOperationException(errorMessage, x);
+                throw new InvalidOperationException(commonErrorMsg, x);
             }
-
-            logger.Info($"RavenDB persistence using DTC transaction recovery storage located at `{fullPath}`.");
-
-            return storage;
         }
     }
 }

--- a/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
+++ b/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
@@ -103,6 +103,11 @@
     <Compile Include="SagaPersister\RavenDbSagaStorage.cs" />
     <Compile Include="SagaPersister\SagaPersister.cs" />
     <Compile Include="SagaPersister\SagaUniqueIdentity.cs" />
+    <Compile Include="Shutdown\IContainShutdownDelegates.cs" />
+    <Compile Include="Shutdown\IRegisterShutdownDelegates.cs" />
+    <Compile Include="Shutdown\RavenDBShutdownHook.cs" />
+    <Compile Include="Shutdown\ShutdownDelegateRegistry.cs" />
+    <Compile Include="Shutdown\ShutdownHook.cs" />
     <Compile Include="Subscriptions\Installer.cs" />
     <Compile Include="Subscriptions\MessageTypeConverter.cs" />
     <Compile Include="Subscriptions\RavenDbSubscriptionSettingsExtensions.cs" />

--- a/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
+++ b/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Internal\RavenDbPersistenceSettingsExtensions.cs" />
     <Compile Include="Internal\SingleSharedDocumentStore.cs" />
     <Compile Include="Internal\StorageEngineVerifier.cs" />
+    <Compile Include="Internal\RavenTransactionRecoveryStorageCreator.cs" />
     <Compile Include="Outbox\Installer.cs" />
     <Compile Include="Outbox\OutboxPersister.cs" />
     <Compile Include="Outbox\OutboxRecord.cs" />

--- a/src/NServiceBus.RavenDB/RavenDBPersistence.cs
+++ b/src/NServiceBus.RavenDB/RavenDBPersistence.cs
@@ -21,6 +21,7 @@
             {
                 RavenLogManager.CurrentLogManager = new NoOpLogManager();
 
+                s.EnableFeatureByDefault<RavenDbShutdownHook>();
                 s.EnableFeatureByDefault<RavenDbStorageSession>();
                 s.EnableFeatureByDefault<SharedDocumentStore>();
             });

--- a/src/NServiceBus.RavenDB/Shutdown/IContainShutdownDelegates.cs
+++ b/src/NServiceBus.RavenDB/Shutdown/IContainShutdownDelegates.cs
@@ -1,0 +1,10 @@
+﻿namespace NServiceBus.RavenDB.Shutdown
+{
+    using System;
+    using System.Collections.Generic;
+
+    interface IContainShutdownDelegates
+    {
+        IEnumerable<Action> GetDelegates();
+    }
+}

--- a/src/NServiceBus.RavenDB/Shutdown/IRegisterShutdownDelegates.cs
+++ b/src/NServiceBus.RavenDB/Shutdown/IRegisterShutdownDelegates.cs
@@ -1,0 +1,9 @@
+﻿namespace NServiceBus.RavenDB.Shutdown
+{
+    using System;
+
+    interface IRegisterShutdownDelegates
+    {
+        void Register(Action action);
+    }
+}

--- a/src/NServiceBus.RavenDB/Shutdown/RavenDBShutdownHook.cs
+++ b/src/NServiceBus.RavenDB/Shutdown/RavenDBShutdownHook.cs
@@ -1,0 +1,16 @@
+﻿namespace NServiceBus.Features
+{
+    using NServiceBus.RavenDB.Shutdown;
+
+    class RavenDbShutdownHook : Feature
+    {
+        RavenDbShutdownHook()
+        {
+        }
+
+        protected override void Setup(FeatureConfigurationContext context)
+        {
+            context.Container.ConfigureComponent<ShutdownDelegateRegistry>(DependencyLifecycle.SingleInstance);
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB/Shutdown/ShutdownDelegateRegistry.cs
+++ b/src/NServiceBus.RavenDB/Shutdown/ShutdownDelegateRegistry.cs
@@ -1,0 +1,20 @@
+﻿namespace NServiceBus.RavenDB.Shutdown
+{
+    using System;
+    using System.Collections.Generic;
+
+    class ShutdownDelegateRegistry : IRegisterShutdownDelegates, IContainShutdownDelegates
+    {
+        private List<Action> shutdownDelegates = new List<Action>();
+
+        public void Register(Action action)
+        {
+            shutdownDelegates.Add(action);
+        }
+
+        public IEnumerable<Action> GetDelegates()
+        {
+            return shutdownDelegates;
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB/Shutdown/ShutdownHook.cs
+++ b/src/NServiceBus.RavenDB/Shutdown/ShutdownHook.cs
@@ -1,0 +1,29 @@
+﻿namespace NServiceBus.RavenDB.Shutdown
+{
+    /// <summary>
+    /// This class is to be ported to the Endpoint level in NServiceBus core.
+    /// This allows us to fix the timeout shutdown bug without also needing to patch core.
+    /// </summary>
+    class ShutdownHook : IWantToRunWhenBusStartsAndStops
+    {
+        public ShutdownHook(IContainShutdownDelegates shutdownRegistry)
+        {
+            this.shutdownRegistry = shutdownRegistry;
+        }
+
+        public void Start()
+        {
+        }
+
+        public void Stop()
+        {
+            var shutdownDelegates = shutdownRegistry.GetDelegates();
+            foreach (var shutdownDelegate in shutdownDelegates)
+            {
+                shutdownDelegate.Invoke();
+            }
+        }
+
+        IContainShutdownDelegates shutdownRegistry;
+    }
+}

--- a/src/NServiceBus.RavenDB/Timeouts/RavenDbTimeoutStorage.cs
+++ b/src/NServiceBus.RavenDB/Timeouts/RavenDbTimeoutStorage.cs
@@ -21,7 +21,7 @@
 
             context.Container.ConfigureComponent<Installer>(DependencyLifecycle.InstancePerCall)
                 .ConfigureProperty(c => c.StoreToInstall, store);
-
+            
             context.Container.ConfigureComponent<TimeoutPersister>(DependencyLifecycle.SingleInstance)
                 .ConfigureProperty(x => x.DocumentStore, store)
                 .ConfigureProperty(x => x.EndpointName, context.Settings.EndpointName());


### PR DESCRIPTION
Connects to #136

(And is a fix for #162, a bug in the initial release)

Possible solution to bug in 3.1.0. Not saying it's *the* solution.

Basically, this will go nearly to the ends of earth trying to use LocalDirectoryTransactionRecoveryStorage:

* Look for an appSetting `RavenDB/TransactionRecoveryStorage/BasePath`
  * If found but can't use it, throw
* Look for a value configured by an extension method `.SetTransactionRecoveryStorageBasePath(basePath)`
  * If found but can't use it, throw
* Try to use LocalAppData
* Try to use AppData
* Try to use ProgramData
* Throw hands up in the air, go back to using IsolatedStorage like 3.0.x did, and warn the user suggesting using the appSetting or config method.

@Particular/tf-async-persistence @Particular/persistence-maintainers