### PR TITLE
Adding SetRavenSession extension for IMessageHandlerContext

### DIFF
--- a/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
+++ b/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Subscriptions\SubscriptionPersister.cs" />
     <Compile Include="Subscriptions\Subscription.cs" />
     <Compile Include="Subscriptions\SubscriptionV1toV2Converter.cs" />
+    <Compile Include="Testing\TestableRavenStorageSession.cs" />
     <Compile Include="Timeouts\QueryTimeouts.cs" />
     <Compile Include="Timeouts\RavenDbTimeoutSettingsExtensions.cs" />
     <Compile Include="Timeouts\RavenDbTimeoutStorage.cs" />

--- a/src/NServiceBus.RavenDB/SessionManagement/RavenSessionExtension.cs
+++ b/src/NServiceBus.RavenDB/SessionManagement/RavenSessionExtension.cs
@@ -27,15 +27,5 @@ namespace NServiceBus
 
             return synchronizedStorageSession.Session;
         }
-
-        /// <summary>
-        /// Sets the current RavenDB session received by <see cref="RavenSession"/>.
-        /// </summary>
-        /// <param name="context"></param>
-        /// <param name="session"></param>
-        public static void SetRavenSession(this IMessageHandlerContext context, IAsyncDocumentSession session)
-        {
-            context.Extensions.Set<SynchronizedStorageSession>(new RavenDBSynchronizedStorageSession(session, true));
-        }
     }
 }

--- a/src/NServiceBus.RavenDB/SessionManagement/RavenSessionExtension.cs
+++ b/src/NServiceBus.RavenDB/SessionManagement/RavenSessionExtension.cs
@@ -27,5 +27,15 @@ namespace NServiceBus
 
             return synchronizedStorageSession.Session;
         }
+
+        /// <summary>
+        /// Sets the current RavenDB session received by <see cref="RavenSession"/>.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="session"></param>
+        public static void SetRavenSession(this IMessageHandlerContext context, IAsyncDocumentSession session)
+        {
+            context.Extensions.Set<SynchronizedStorageSession>(new RavenDBSynchronizedStorageSession(session, true));
+        }
     }
 }

--- a/src/NServiceBus.RavenDB/Testing/TestableRavenStorageSession.cs
+++ b/src/NServiceBus.RavenDB/Testing/TestableRavenStorageSession.cs
@@ -1,0 +1,25 @@
+﻿namespace NServiceBus.Testing
+{
+    using Persistence;
+    using Raven.Client;
+
+    /// <summary>
+    /// A fake implementation for <see cref="SynchronizedStorageSession"/> for testing purposes.
+    /// </summary>
+    public class TestableRavenStorageSession : SynchronizedStorageSession
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="TestableRavenStorageSession"/> using the provided <see cref="IAsyncDocumentSession"/>.
+        /// </summary>
+        /// <param name="session"></param>
+        public TestableRavenStorageSession(IAsyncDocumentSession session)
+        {
+            Session = session;
+        }
+
+        /// <summary>
+        /// The document session which is retrieved by calling <see cref="RavenSessionExtension.RavenSession"/>.
+        /// </summary>
+        public IAsyncDocumentSession Session { get; private set; }
+    }
+}


### PR DESCRIPTION
Connects to Particular/NServiceBus.Testing#29

For testability users need to be able to configure a session on `IMessageHandlerContext` so that `context.SynchronizedStorage.RavenSession()` works correctly.