### PR TITLE
Use new instance of document store to delete databases

### DIFF
--- a/src/NServiceBus.RavenDB.AcceptanceTests/When_raven_session_is_provided.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/When_raven_session_is_provided.cs
@@ -45,7 +45,7 @@
 
                 if (documentStore != null)
                 {
-                    await ConfigureEndpointRavenDBPersistence.DeleteDatabase(documentStore);
+                    await ConfigureEndpointRavenDBPersistence.DeleteDatabase(documentStore.DefaultDatabase);
                 }
             }
         }


### PR DESCRIPTION
The `DocumentStore` instance for the test is disposed of by the time the Cleanup method is called.
This stops almost all databases from leaking for the acceptance tests project.
There are still a couple left.

PING @DavidBoike 

@Particular/persistence-maintainers