### PR TITLE
Unable to deserialize SagaUniqueIdentity in NServiceBus.RavenDB package when migrating from NServiceBus version 4

### DIFF
--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,4 @@
 assembly-versioning-scheme: Major
+branches:
+  develop:
+    tag: alpha

--- a/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
+++ b/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
@@ -115,6 +115,7 @@
     <Compile Include="RavenTestBase.cs" />
     <Compile Include="SagaPersister\Saga_with_unique_property_set_to_null.cs" />
     <Compile Include="SagaPersister\When_completing_a_saga_with_the_raven_persister.cs" />
+    <Compile Include="SagaPersister\When_loading_a_legacy_unique_identity.cs" />
     <Compile Include="SagaPersister\When_persisting_a_saga_entity_with_an_Enum_property.cs" />
     <Compile Include="SagaPersister\When_persisting_a_saga_entity_with_a_concrete_class_property.cs" />
     <Compile Include="SagaPersister\When_persisting_a_saga_entity_with_a_date_time_property.cs" />

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_loading_a_legacy_unique_identity.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_loading_a_legacy_unique_identity.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using NServiceBus.RavenDB.Persistence.SagaPersister;
+using NServiceBus.RavenDB.Tests;
+using NServiceBus.Saga;
+using NServiceBus.SagaPersisters.RavenDB;
+using NUnit.Framework;
+using Raven.Abstractions.Data;
+using Raven.Client;
+using Raven.Client.Document;
+using Raven.Json.Linq;
+
+[TestFixture]
+class When_loading_a_saga_with_legacy_unique_identity
+{
+    [Test]
+    public void It_should_load_successfully()
+    {
+        using (var store = DocumentStoreBuilder.Build())
+        {
+            var unique = Guid.NewGuid().ToString();
+
+            CreateLegacySagaDocuments(store, unique);
+
+            var factory = new RavenSessionFactory(store);
+            factory.ReleaseSession();
+            var persister = new SagaPersister(factory);
+
+            var saga = persister.Get<SagaWithUniqueProperty>("UniqueString", unique);
+
+            Assert.IsNotNull(saga, "Saga is null");
+
+            persister.Complete(saga);
+            factory.SaveChanges();
+
+            Assert.IsNull(persister.Get<SagaWithUniqueProperty>("UniqueString", unique), "Saga was not completed");
+        }
+    }
+
+    class SagaWithUniqueProperty : IContainSagaData
+    {
+        public Guid Id { get; set; }
+        public string Originator { get; set; }
+        public string OriginalMessageId { get; set; }
+
+        [Unique]
+        public string UniqueString { get; set; }
+
+    }
+
+    void CreateLegacySagaDocuments(IDocumentStore store, string unique)
+    {
+        var sagaId = Guid.NewGuid();
+
+        var saga = new SagaWithUniqueProperty
+        {
+            Id = sagaId,
+            UniqueString = unique
+        };
+
+        var sagaDocId = $"SagaWithUniqueProperty/{sagaId}";
+
+        DirectStore(store, sagaDocId, saga, "SagaWithUniqueProperty", ReflectionUtil.GetFullNameWithoutVersionInformation(typeof(SagaWithUniqueProperty)), unique);
+
+        var uniqueIdentity = new SagaUniqueIdentity
+        {
+            Id = SagaUniqueIdentity.FormatId(typeof(SagaWithUniqueProperty), new KeyValuePair<string, object>("UniqueString", unique)),
+            SagaId = sagaId,
+            SagaDocId = sagaDocId,
+            UniqueValue = unique
+        };
+
+        DirectStore(store, uniqueIdentity.Id, uniqueIdentity, "SagaUniqueIdentity", "NServiceBus.Persistence.Raven.SagaPersister.SagaUniqueIdentity, NServiceBus.Core");
+    }
+
+    static void DirectStore(IDocumentStore store, string id, object document, string entityName, string typeName, string uniqueValue = null)
+    {
+        var jsonDoc = RavenJObject.FromObject(document);
+        var metadata = new RavenJObject();
+        metadata[Constants.RavenEntityName] = entityName;
+        metadata[Constants.RavenClrType] = typeName;
+        if (uniqueValue != null)
+            metadata["NServiceBus-UniqueValue"] = uniqueValue;
+        Console.WriteLine($"Creating {entityName}: {id}");
+        store.DatabaseCommands.Put(id, Etag.Empty, jsonDoc, metadata);
+    }
+}

--- a/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
+++ b/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
@@ -15,7 +15,8 @@
     <SignAssembly>true</SignAssembly>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
-    <NuGetPackageImportStamp>059b726d</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -110,17 +111,18 @@
     <Compile Include="Timeouts\TimeoutsIndex.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\GitVersionTask.2.0.1\Build\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.2.0.1\Build\GitVersionTask.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\GitVersionTask.2.0.1\Build\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.2.0.1\Build\GitVersionTask.targets'))" />
-    <Error Condition="!Exists('..\packages\NuGetPackager.0.5.4\build\NuGetPackager.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuGetPackager.0.5.4\build\NuGetPackager.targets'))" />
+    <Error Condition="!Exists('..\packages\GitVersionTask.3.4.1\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.3.4.1\build\dotnet\GitVersionTask.targets'))" />
+    <Error Condition="!Exists('..\packages\NuGetPackager.0.6.0\build\NuGetPackager.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuGetPackager.0.6.0\build\NuGetPackager.targets'))" />
   </Target>
-  <Import Project="..\packages\NuGetPackager.0.5.4\build\NuGetPackager.targets" Condition="Exists('..\packages\NuGetPackager.0.5.4\build\NuGetPackager.targets')" />
-  <Import Project="..\packages\GitVersionTask.1.3.3\Build\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.1.3.3\Build\GitVersionTask.targets')" />
+  <Import Project="..\packages\GitVersionTask.3.4.1\build\dotnet\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.3.4.1\build\dotnet\GitVersionTask.targets')" />
+  <Import Project="..\packages\NuGetPackager.0.6.0\build\NuGetPackager.targets" Condition="Exists('..\packages\NuGetPackager.0.6.0\build\NuGetPackager.targets')" />
 </Project>

--- a/src/NServiceBus.RavenDB/SagaPersister/SagaPersister.cs
+++ b/src/NServiceBus.RavenDB/SagaPersister/SagaPersister.cs
@@ -124,6 +124,8 @@ namespace NServiceBus.SagaPersisters.RavenDB
 
             if (lookup != null)
             {
+                sessionProvider.Session.Advanced.Evict(lookup); //don't track. We store/delete SagaUniqueIdentity explicitly
+
                 return lookup.SagaDocId != null
                     ? sessionProvider.Session.Load<T>(lookup.SagaDocId) //if we have a saga id we can just load it
                     : Get<T>(lookup.SagaId); //if not this is a saga that was created pre 3.0.4 so we fallback to a get instead

--- a/src/NServiceBus.RavenDB/packages.config
+++ b/src/NServiceBus.RavenDB/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GitVersionTask" version="2.0.1" targetFramework="net45" />
+  <package id="GitVersionTask" version="3.4.1" targetFramework="net45" developmentDependency="true" />
   <package id="NServiceBus" version="5.2.8" targetFramework="net45" />
-  <package id="NuGetPackager" version="0.5.4" targetFramework="net45" />
+  <package id="NuGetPackager" version="0.6.0" targetFramework="net45" developmentDependency="true" />
   <package id="RavenDB.Client" version="2.5.2916" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
## Description

SagaUniqueIdentity was changed from `NServiceBus.Persistence.Raven.SagaPersister.SagaUniqueIdentity, NServiceBus.Core` to `NServiceBus.RavenDB.Persistence.SagaPersister, NServiceBus.RavenDB` when Raven support was moved into its own package. This is problematic because RavenDB stores the CLR-type as part of the metadata on documents. If a saga with a unique property was stored with the internal raven support in core, it blows up if it is loaded from the code in the external package. The following error is thrown by the raven client library:


```
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.InvalidCastException: Unable to cast object of type 'NServiceBus.Persistence.Raven.SagaPersister.SagaUniqueIdentity' to type 'NServiceBus.RavenDB.Persistence.SagaPersister.SagaUniqueIdentity'.
   at Raven.Client.Document.InMemoryDocumentSessionOperations.TrackEntity[T](JsonDocument documentFound)
   at Raven.Client.Document.SessionOperations.MultiLoadOperation.<Complete>b__4[T](JsonDocument document)
   at System.Linq.Enumerable.WhereSelectArrayIterator`2.MoveNext()
   at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
  at Raven.Client.Document.SessionOperations.MultiLoadOperation.Complete[T]()
   at Raven.Client.Document.MultiLoaderWithInclude`1.Load[TResult](String id)
   at NServiceBus.RavenDB.Persistence.SagaPersister.RavenSagaPersister.GetByUniqueProperty[T](String property, Object value) in
 ```

## Who's affected

Customers who meet all of the following conditions:

* Customers migrating from the internal Raven support in NServiceBus 4/Raven Server 2.0 to any version of the external package(Raven Server 2.5 or 3)
* Customers who are also using Sagas and their implementation of `IContainSagaData` utilizes the `Unique` attribute

## Symptoms

On of the following exceptions is thrown while processing a Saga:

*For NServiceBus.RavenDb version 1.x*

```
NServiceBus throws "System.InvalidCastException: Unable to cast object of type 'NServiceBus.Persistence.Raven.SagaPersister.SagaUniqueIdentity' to type 'NServiceBus.RavenDB.Persistence.SagaPersister.SagaUniqueIdentity'" when a saga created by internal Raven code is loaded by the external Raven package.
```

*For later versions of NServiceBus.RavenDb*

```
Raven.Abstractions.Exceptions.ConcurrencyException : PUT attempted on document '{sagaid}' using a non current etag (document deleted)
```

## Steps to reproduce

1. Start a console project
2. Install any version NServiceBus using the internal RavenDB support. For example 4.7.12
3. Install RavenDB Server 2.0
4. Add a saga with a unique attribute and store using RavenDB saga persister (Use [Sample20](https://github.com/Particular/Raven188Repro/tree/master/src/Sample20))
5. Upgrade RavenDB Server from 2.0 to 2.5(or 3)
6. Update to use the external RavenDB package. For example RavenDB 1.0.3/2.2.4 for Raven Server 2.5 or 3.0.6 for Raven Server 3.0
7. Load the saga created in 4 (Use [Sample25](https://github.com/Particular/Raven188Repro/tree/master/src/Sample25))
8. Throws 
```
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.InvalidCastException: Unable to cast object of type 'NServiceBus.Persistence.Raven.SagaPersister.SagaUniqueIdentity' to type 'NServiceBus.RavenDB.Persistence.SagaPersister.SagaUniqueIdentity'.`
```

Reproduced on NServiceBus 4.6.10 to 4.7.12 with NServiceBus.RavenDB 1.0.3.