### PR TITLE
Bumping nuspec requirement for RavenDB.Client to match packages.config

### DIFF
--- a/src/NServiceBus.RavenDB.AcceptanceTests/NServiceBus.RavenDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/NServiceBus.RavenDB.AcceptanceTests.csproj
@@ -57,11 +57,11 @@
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Raven.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <HintPath>..\packages\RavenDB.Client.3.0.30037\lib\net45\Raven.Abstractions.dll</HintPath>
+      <HintPath>..\packages\RavenDB.Client.3.0.30000\lib\net45\Raven.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Raven.Client.Lightweight, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <HintPath>..\packages\RavenDB.Client.3.0.30037\lib\net45\Raven.Client.Lightweight.dll</HintPath>
+      <HintPath>..\packages\RavenDB.Client.3.0.30000\lib\net45\Raven.Client.Lightweight.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/NServiceBus.RavenDB.AcceptanceTests/packages.config
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/packages.config
@@ -5,7 +5,7 @@
   <package id="NServiceBus.AcceptanceTesting" version="6.0.0-beta0001" targetFramework="net452" />
   <package id="NServiceBus.AcceptanceTests.Sources" version="6.0.0-beta0001" targetFramework="net452" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
-  <package id="RavenDB.Client" version="3.0.30037" targetFramework="net452" />
+  <package id="RavenDB.Client" version="3.0.30000" targetFramework="net452" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />

--- a/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
+++ b/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
@@ -85,23 +85,23 @@
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Raven.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <HintPath>..\packages\RavenDB.Tests.Helpers.3.0.30037\lib\net45\Raven.Abstractions.dll</HintPath>
+      <HintPath>..\packages\RavenDB.Tests.Helpers.3.0.30000\lib\net45\Raven.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Raven.Client.Lightweight, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <HintPath>..\packages\RavenDB.Client.3.0.30037\lib\net45\Raven.Client.Lightweight.dll</HintPath>
+      <HintPath>..\packages\RavenDB.Client.3.0.30000\lib\net45\Raven.Client.Lightweight.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Raven.Database, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <HintPath>..\packages\RavenDB.Database.3.0.30037\lib\net45\Raven.Database.dll</HintPath>
+      <HintPath>..\packages\RavenDB.Database.3.0.30000\lib\net45\Raven.Database.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Raven.Server, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <HintPath>..\packages\RavenDB.Tests.Helpers.3.0.30037\lib\net45\Raven.Server.exe</HintPath>
+      <HintPath>..\packages\RavenDB.Tests.Helpers.3.0.30000\lib\net45\Raven.Server.exe</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Raven.Tests.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <HintPath>..\packages\RavenDB.Tests.Helpers.3.0.30037\lib\net45\Raven.Tests.Helpers.dll</HintPath>
+      <HintPath>..\packages\RavenDB.Tests.Helpers.3.0.30000\lib\net45\Raven.Tests.Helpers.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/NServiceBus.RavenDB.Tests/packages.config
+++ b/src/NServiceBus.RavenDB.Tests/packages.config
@@ -6,8 +6,8 @@
   <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net452" />
   <package id="NServiceBus" version="6.0.0-beta0001" targetFramework="net452" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
-  <package id="RavenDB.Client" version="3.0.30037" targetFramework="net452" />
-  <package id="RavenDB.Database" version="3.0.30037" targetFramework="net452" />
-  <package id="RavenDB.Embedded" version="3.0.30037" targetFramework="net452" />
-  <package id="RavenDB.Tests.Helpers" version="3.0.30037" targetFramework="net452" />
+  <package id="RavenDB.Client" version="3.0.30000" targetFramework="net452" />
+  <package id="RavenDB.Database" version="3.0.30000" targetFramework="net452" />
+  <package id="RavenDB.Embedded" version="3.0.30000" targetFramework="net452" />
+  <package id="RavenDB.Tests.Helpers" version="3.0.30000" targetFramework="net452" />
 </packages>

--- a/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
+++ b/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
@@ -58,11 +58,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Raven.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <HintPath>..\packages\RavenDB.Client.3.0.30037\lib\net45\Raven.Abstractions.dll</HintPath>
+      <HintPath>..\packages\RavenDB.Client.3.0.30000\lib\net45\Raven.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Raven.Client.Lightweight, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <HintPath>..\packages\RavenDB.Client.3.0.30037\lib\net45\Raven.Client.Lightweight.dll</HintPath>
+      <HintPath>..\packages\RavenDB.Client.3.0.30000\lib\net45\Raven.Client.Lightweight.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/NServiceBus.RavenDB/packages.config
+++ b/src/NServiceBus.RavenDB/packages.config
@@ -6,5 +6,5 @@
   <package id="NuGetPackager" version="0.6.0" targetFramework="net452" developmentDependency="true" />
   <package id="Obsolete.Fody" version="4.0.3" targetFramework="net451" developmentDependency="true" />
   <package id="Particular.CodeRules" version="0.1.1" targetFramework="net452" developmentDependency="true" />
-  <package id="RavenDB.Client" version="3.0.30037" targetFramework="net452" />
+  <package id="RavenDB.Client" version="3.0.30000" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Changing the nuspec for RavenDB.Client

* packages.config uses 3.0.30037
* nuspec used 3.0.30000 - updated to 3.0.30037 to match.

Not sure if this is the right call, or if the packages.config should be downgraded to 30000 and we should rerun all tests.

* 30000 was released Nov 19, 2015, and is the lowest package I think we can responsibly use.
* 30037 was released Jan 9, as part of a commit where @johnsimons [updated everything](https://github.com/Particular/NServiceBus.RavenDB/commit/4d3282c87f51dcdaed0c77c08a18743db36eb915) - not sure if there was a concrete reason to upgrade the Raven client as well?

@SimonCropp I know you've got a lot of wisdom in this area, so I'm hoping you'll share some as well.

@Particular/ravendb-persistence-maintainers 