### PR TITLE
Fixes from AsyncFixer, except for acceptance tests from core source packages

### DIFF
--- a/src/NServiceBus.RavenDB.AcceptanceTests/When_outbox_is_enabled.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/When_outbox_is_enabled.cs
@@ -72,17 +72,17 @@
 
             class DuplicateMessageHandler : IHandleMessages<DuplicateMessage>
             {
-                public async Task Handle(DuplicateMessage message, IMessageHandlerContext context)
+                public Task Handle(DuplicateMessage message, IMessageHandlerContext context)
                 {
-                    await context.Send(new DownstreamMessage());
+                    return context.Send(new DownstreamMessage());
                 }
             }
 
             class MarkerMessageHandler : IHandleMessages<MarkerMessage>
             {
-                public async Task Handle(MarkerMessage message, IMessageHandlerContext context)
+                public Task Handle(MarkerMessage message, IMessageHandlerContext context)
                 {
-                    await context.Send(message);
+                    return context.Send(message);
                 }
             }
         }

--- a/src/NServiceBus.RavenDB.AcceptanceTests/When_using_a_sagafinder.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/When_using_a_sagafinder.cs
@@ -45,14 +45,14 @@
             {
                 public Context Context { get; set; }
 
-                public async Task<SagaFinderSagaData> FindBy(StartSagaMessage message, SynchronizedStorageSession session, ReadOnlyContextBag options)
+                public Task<SagaFinderSagaData> FindBy(StartSagaMessage message, SynchronizedStorageSession session, ReadOnlyContextBag options)
                 {
                     if (Context.SagaId == Guid.Empty)
                     {
-                        return await Task.FromResult(default(SagaFinderSagaData));
+                        return Task.FromResult(default(SagaFinderSagaData));
                     }
 
-                    return await session.RavenSession().LoadAsync<SagaFinderSagaData>(Context.SagaId).ConfigureAwait(false);
+                    return session.RavenSession().LoadAsync<SagaFinderSagaData>(Context.SagaId);
                 }
             }
 

--- a/src/NServiceBus.RavenDB.Tests/Outbox/When_cleaning_outbox_messages.cs
+++ b/src/NServiceBus.RavenDB.Tests/Outbox/When_cleaning_outbox_messages.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.Extensibility;
     using NServiceBus.Outbox;
@@ -52,7 +51,7 @@
 
 
             await persister.SetAsDispatched(id, context);
-            Thread.Sleep(TimeSpan.FromSeconds(1)); //Need to wait for dispatch logic to finish
+            await Task.Delay(TimeSpan.FromSeconds(1)); //Need to wait for dispatch logic to finish
 
             //WaitForUserToContinueTheTest(store);
             WaitForIndexing(store);

--- a/src/NServiceBus.RavenDB.Tests/Persistence/DocumentIds/DocumentIdConventionTestBase.cs
+++ b/src/NServiceBus.RavenDB.Tests/Persistence/DocumentIds/DocumentIdConventionTestBase.cs
@@ -11,7 +11,7 @@
     {
         protected const string EndpointName = "FakeEndpoint";
 
-        protected async Task DirectStore(IDocumentStore store, string id, object document, string entityName)
+        protected Task DirectStore(IDocumentStore store, string id, object document, string entityName)
         {
             var jsonDoc = RavenJObject.FromObject(document);
             var metadata = new RavenJObject();
@@ -20,10 +20,10 @@
             metadata["Raven-Clr-Type"] = $"{type.FullName}, {type.Assembly.GetName().Name}";
 
             Console.WriteLine($"Creating {entityName}: {id}");
-            await store.AsyncDatabaseCommands.PutAsync(id, Etag.Empty, jsonDoc, metadata);
+            return store.AsyncDatabaseCommands.PutAsync(id, Etag.Empty, jsonDoc, metadata);
         }
 
-        protected async Task StoreHiLo(IDocumentStore store, string entityName)
+        protected Task StoreHiLo(IDocumentStore store, string entityName)
         {
             string hiloId = $"Raven/Hilo/{entityName}";
             var document = new RavenJObject();
@@ -31,7 +31,7 @@
             var metadata = new RavenJObject();
 
             Console.WriteLine($"Creating {hiloId}");
-            await store.AsyncDatabaseCommands.PutAsync(hiloId, null, document, metadata);
+            return store.AsyncDatabaseCommands.PutAsync(hiloId, null, document, metadata);
         }
 
         public enum ConventionType

--- a/src/NServiceBus.RavenDB.Tests/Timeouts/Should_not_skip_timeouts.cs
+++ b/src/NServiceBus.RavenDB.Tests/Timeouts/Should_not_skip_timeouts.cs
@@ -27,7 +27,7 @@
                 DefaultDatabase = db
             }.Initialize())
             {
-                await new TimeoutsIndex().ExecuteAsync(documentStore);
+                new TimeoutsIndex().Execute(documentStore);
 
                 var query = new QueryTimeouts(documentStore, "foo")
                 {
@@ -44,7 +44,7 @@
                 var lastTimeout = DateTime.UtcNow;
                 var finishedAdding = false;
 
-                new Thread(async () =>
+                new Thread(() =>
                 {
                     var sagaId = Guid.NewGuid();
                     for (var i = 0; i < 10000; i++)
@@ -56,7 +56,7 @@
                             Time = DateTime.UtcNow.AddSeconds(RandomProvider.GetThreadRandom().Next(1, 20)),
                             OwningTimeoutManager = string.Empty
                         };
-                        await persister.Add(td, context);
+                        persister.Add(td, context).Wait();
                         expected.Add(new Tuple<string, DateTime>(td.Id, td.Time));
                         lastTimeout = (td.Time > lastTimeout) ? td.Time : lastTimeout;
                     }
@@ -123,7 +123,7 @@
                 DefaultDatabase = db
             }.Initialize())
             {
-                await new TimeoutsIndex().ExecuteAsync(documentStore);
+                new TimeoutsIndex().Execute(documentStore);
 
                 var query = new QueryTimeouts(documentStore, "foo")
                 {
@@ -142,7 +142,7 @@
                 var finishedAdding1 = false;
                 var finishedAdding2 = false;
 
-                new Thread(async () =>
+                new Thread(() =>
                 {
                     var sagaId = Guid.NewGuid();
                     for (var i = 0; i < insertsPerThread; i++)
@@ -154,7 +154,7 @@
                             Time = DateTime.UtcNow.AddSeconds(RandomProvider.GetThreadRandom().Next(1, 20)),
                             OwningTimeoutManager = string.Empty
                         };
-                        await persister.Add(td, context);
+                        persister.Add(td, context).Wait();
                         Interlocked.Increment(ref expected);
                         lastExpectedTimeout = (td.Time > lastExpectedTimeout) ? td.Time : lastExpectedTimeout;
                     }
@@ -162,7 +162,7 @@
                     Console.WriteLine("*** Finished adding ***");
                 }).Start();
 
-                new Thread(async () =>
+                new Thread(() =>
                 {
                     using (var store = new DocumentStore
                     {
@@ -182,7 +182,7 @@
                                 Time = DateTime.UtcNow.AddSeconds(RandomProvider.GetThreadRandom().Next(1, 20)),
                                 OwningTimeoutManager = string.Empty
                             };
-                            await persister2.Add(td, context);
+                            persister2.Add(td, context).Wait();
                             Interlocked.Increment(ref expected);
                             lastExpectedTimeout = (td.Time > lastExpectedTimeout) ? td.Time : lastExpectedTimeout;
                         }

--- a/src/NServiceBus.RavenDB.Tests/Timeouts/Should_not_skip_timeouts.cs
+++ b/src/NServiceBus.RavenDB.Tests/Timeouts/Should_not_skip_timeouts.cs
@@ -27,7 +27,7 @@
                 DefaultDatabase = db
             }.Initialize())
             {
-                new TimeoutsIndex().Execute(documentStore);
+                await new TimeoutsIndex().ExecuteAsync(documentStore);
 
                 var query = new QueryTimeouts(documentStore, "foo")
                 {
@@ -44,7 +44,7 @@
                 var lastTimeout = DateTime.UtcNow;
                 var finishedAdding = false;
 
-                new Thread(() =>
+                new Thread(async () =>
                 {
                     var sagaId = Guid.NewGuid();
                     for (var i = 0; i < 10000; i++)
@@ -56,7 +56,7 @@
                             Time = DateTime.UtcNow.AddSeconds(RandomProvider.GetThreadRandom().Next(1, 20)),
                             OwningTimeoutManager = string.Empty
                         };
-                        persister.Add(td, context).Wait();
+                        await persister.Add(td, context);
                         expected.Add(new Tuple<string, DateTime>(td.Id, td.Time));
                         lastTimeout = (td.Time > lastTimeout) ? td.Time : lastTimeout;
                     }
@@ -123,7 +123,7 @@
                 DefaultDatabase = db
             }.Initialize())
             {
-                new TimeoutsIndex().Execute(documentStore);
+                await new TimeoutsIndex().ExecuteAsync(documentStore);
 
                 var query = new QueryTimeouts(documentStore, "foo")
                 {
@@ -142,7 +142,7 @@
                 var finishedAdding1 = false;
                 var finishedAdding2 = false;
 
-                new Thread(() =>
+                new Thread(async () =>
                 {
                     var sagaId = Guid.NewGuid();
                     for (var i = 0; i < insertsPerThread; i++)
@@ -154,7 +154,7 @@
                             Time = DateTime.UtcNow.AddSeconds(RandomProvider.GetThreadRandom().Next(1, 20)),
                             OwningTimeoutManager = string.Empty
                         };
-                        persister.Add(td, context).Wait();
+                        await persister.Add(td, context);
                         Interlocked.Increment(ref expected);
                         lastExpectedTimeout = (td.Time > lastExpectedTimeout) ? td.Time : lastExpectedTimeout;
                     }
@@ -162,7 +162,7 @@
                     Console.WriteLine("*** Finished adding ***");
                 }).Start();
 
-                new Thread(() =>
+                new Thread(async () =>
                 {
                     using (var store = new DocumentStore
                     {
@@ -182,7 +182,7 @@
                                 Time = DateTime.UtcNow.AddSeconds(RandomProvider.GetThreadRandom().Next(1, 20)),
                                 OwningTimeoutManager = string.Empty
                             };
-                            persister2.Add(td, context).Wait();
+                            await persister2.Add(td, context);
                             Interlocked.Increment(ref expected);
                             lastExpectedTimeout = (td.Time > lastExpectedTimeout) ? td.Time : lastExpectedTimeout;
                         }

--- a/src/NServiceBus.RavenDB.Tests/Timeouts/When_removing_timeouts_from_storage.cs
+++ b/src/NServiceBus.RavenDB.Tests/Timeouts/When_removing_timeouts_from_storage.cs
@@ -75,7 +75,7 @@
                 }
             });
 
-            Assert.IsTrue(t1.Result | t2.Result, "the document should be deleted");
+            Assert.IsTrue(await t1 | await t2, "the document should be deleted");
             Assert.IsFalse(t1.Result && t2.Result, "only one operation should complete successfully");
         }
 
@@ -116,7 +116,7 @@
                 }
             });
 
-            Assert.IsTrue(t1.Result | t2.Result, "the document should be deleted");
+            Assert.IsTrue(await t1 | await t2, "the document should be deleted");
             Assert.IsFalse(t1.Result && t2.Result, "only one operation should complete successfully");
         }
 

--- a/src/NServiceBus.RavenDB/Outbox/OutboxPersister.cs
+++ b/src/NServiceBus.RavenDB/Outbox/OutboxPersister.cs
@@ -58,11 +58,11 @@
             return Task.FromResult<OutboxTransaction>(transaction);
         }
 
-        public async Task Store(OutboxMessage message, OutboxTransaction transaction, ContextBag context)
+        public Task Store(OutboxMessage message, OutboxTransaction transaction, ContextBag context)
         {
             var session = ((RavenDBOutboxTransaction)transaction).AsyncSession;
 
-            await session.StoreAsync(new OutboxRecord
+            return session.StoreAsync(new OutboxRecord
             {
                 MessageId = message.MessageId,
                 Dispatched = false,
@@ -73,7 +73,7 @@
                     MessageId = t.MessageId,
                     Options = t.Options
                 }).ToList()
-            }, GetOutboxRecordId(message.MessageId)).ConfigureAwait(false);
+            }, GetOutboxRecordId(message.MessageId));
         }
 
         public async Task SetAsDispatched(string messageId, ContextBag options)

--- a/src/NServiceBus.RavenDB/Outbox/RavenDBOutboxTransaction.cs
+++ b/src/NServiceBus.RavenDB/Outbox/RavenDBOutboxTransaction.cs
@@ -17,9 +17,9 @@
             AsyncSession = null;
         }
 
-        public async Task Commit()
+        public Task Commit()
         {
-            await AsyncSession.SaveChangesAsync().ConfigureAwait(false);
+            return AsyncSession.SaveChangesAsync();
         }
 
         public IAsyncDocumentSession AsyncSession { get; private set; }

--- a/src/NServiceBus.RavenDB/SagaPersister/SagaPersister.cs
+++ b/src/NServiceBus.RavenDB/SagaPersister/SagaPersister.cs
@@ -59,10 +59,10 @@ namespace NServiceBus.Persistence.RavenDB
             return TaskEx.CompletedTask;
         }
 
-        public async Task<T> Get<T>(Guid sagaId, SynchronizedStorageSession session, ContextBag context) where T : IContainSagaData
+        public Task<T> Get<T>(Guid sagaId, SynchronizedStorageSession session, ContextBag context) where T : IContainSagaData
         {
             var documentSession = session.RavenSession();
-            return await documentSession.LoadAsync<T>(sagaId).ConfigureAwait(false);
+            return documentSession.LoadAsync<T>(sagaId);
         }
 
         public async Task<T> Get<T>(string propertyName, object propertyValue, SynchronizedStorageSession session, ContextBag context) where T : IContainSagaData


### PR DESCRIPTION
Connects to Particular/PlatformDevelopment#733

@Particular/ravendb-persistence-maintainers 

Did not change any of the ATs from Core - those will be shipped to us in Core Beta 3. All the warnings from the tool are of the "this method doesn't _really_ need to use async/await" variety so I didn't see the need.