### PR TITLE
DocumentId conventions fail on subsequent runs

### DIFF
--- a/src/NServiceBus.RavenDB.Tests/DocumentIds/InconsistentSagaIdConventions.cs
+++ b/src/NServiceBus.RavenDB.Tests/DocumentIds/InconsistentSagaIdConventions.cs
@@ -30,42 +30,46 @@
                     sagas = Prefill(store, seedType);
                 }
 
-                using (var store = db.NewStore())
+                // Need to ensure multiple runs will work, after conventions document is stored
+                for (var i = 0; i < 3; i++)
                 {
-                    Console.WriteLine($"Testing saga lookups with DocumentStore initially configured for {seedType} conventions.");
-                    ApplyTestConventions(store, seedType);
-                    store.Initialize();
-
-                    foreach (var saga in sagas)
+                    using (var store = db.NewStore())
                     {
-                        var storeAccessor = new StoreAccessor(store);
-                        var sessionFactory = new RavenSessionFactory(storeAccessor);
-                        var persister = new RavenSagaPersister(sessionFactory);
-                        using (sessionFactory.Session)
-                        {
-                            Console.WriteLine($"Retrieving SagaId {saga.Id} by SagaId");
-                            var byId = persister.Get<TestSagaData>(saga.Id);
-                            Assert.IsNotNull(byId);
-                            Assert.AreEqual(byId.Id, saga.Id);
-                            Assert.AreEqual(byId.OrderId, saga.OrderId);
-                            Assert.AreEqual(byId.OriginalMessageId, saga.OriginalMessageId);
-                            Assert.AreEqual(byId.Originator, saga.Originator);
-                            Assert.AreEqual(1, saga.Counter);
-                        }
-                        sessionFactory.ReleaseSession();
+                        Console.WriteLine($"Testing saga lookups with DocumentStore initially configured for {seedType} conventions.");
+                        ApplyTestConventions(store, seedType);
+                        store.Initialize();
 
-                        using (sessionFactory.Session)
+                        foreach (var saga in sagas)
                         {
-                            Console.WriteLine($"Retrieving SagaId {saga.Id} by Correlation Property OrderId={saga.OrderId}");
-                            var byId = persister.Get<TestSagaData>("OrderId", saga.OrderId);
-                            Assert.IsNotNull(byId);
-                            Assert.AreEqual(byId.Id, saga.Id);
-                            Assert.AreEqual(byId.OrderId, saga.OrderId);
-                            Assert.AreEqual(byId.OriginalMessageId, saga.OriginalMessageId);
-                            Assert.AreEqual(byId.Originator, saga.Originator);
-                            Assert.AreEqual(1, saga.Counter);
+                            var storeAccessor = new StoreAccessor(store);
+                            var sessionFactory = new RavenSessionFactory(storeAccessor);
+                            var persister = new RavenSagaPersister(sessionFactory);
+                            using (sessionFactory.Session)
+                            {
+                                Console.WriteLine($"Retrieving SagaId {saga.Id} by SagaId");
+                                var byId = persister.Get<TestSagaData>(saga.Id);
+                                Assert.IsNotNull(byId);
+                                Assert.AreEqual(byId.Id, saga.Id);
+                                Assert.AreEqual(byId.OrderId, saga.OrderId);
+                                Assert.AreEqual(byId.OriginalMessageId, saga.OriginalMessageId);
+                                Assert.AreEqual(byId.Originator, saga.Originator);
+                                Assert.AreEqual(1, saga.Counter);
+                            }
+                            sessionFactory.ReleaseSession();
+
+                            using (sessionFactory.Session)
+                            {
+                                Console.WriteLine($"Retrieving SagaId {saga.Id} by Correlation Property OrderId={saga.OrderId}");
+                                var byId = persister.Get<TestSagaData>("OrderId", saga.OrderId);
+                                Assert.IsNotNull(byId);
+                                Assert.AreEqual(byId.Id, saga.Id);
+                                Assert.AreEqual(byId.OrderId, saga.OrderId);
+                                Assert.AreEqual(byId.OriginalMessageId, saga.OriginalMessageId);
+                                Assert.AreEqual(byId.Originator, saga.Originator);
+                                Assert.AreEqual(1, saga.Counter);
+                            }
+                            sessionFactory.ReleaseSession();
                         }
-                        sessionFactory.ReleaseSession();
                     }
                 }
             }

--- a/src/NServiceBus.RavenDB.Tests/DocumentIds/InconsistentTimeoutIdConventions.cs
+++ b/src/NServiceBus.RavenDB.Tests/DocumentIds/InconsistentTimeoutIdConventions.cs
@@ -45,7 +45,10 @@
                         var index = CreateTimeoutIndex(store);
                         db.WaitForIndexing(store);
 
-                        Assert.AreEqual(index, prefillIndex, "Index definitions must match or previous timeouts will not be found.");
+                        if (i == 0)
+                        {
+                            Assert.AreEqual(index, prefillIndex, "Index definitions must match or previous timeouts will not be found.");
+                        }
 
                         var storeAccessor = new StoreAccessor(store);
                         var persister = new RavenTimeoutPersistence(storeAccessor);

--- a/src/NServiceBus.RavenDB/Internal/DocumentIdConventions.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentIdConventions.cs
@@ -138,6 +138,7 @@
             };
 
             var configuredName = mappingsInPriorityOrder
+                .Distinct()
                 .SingleOrDefault(name => collectionData.Collections.Contains(name));
 
             if (configuredName == null)


### PR DESCRIPTION
## Description

The document id conventions introduced to fix #209 will fail after the first run if providing a DocumentStore instance.

## Who's affected

All customers using NServiceBus.RavenDB 3.0.8, 2.2.6, or 1.0.5 are affected and should upgrade to the latest patch releases.

## Symptoms

The endpoint will fail on startup with an exception similar to the following:

    System.InvalidOperationException : Sequence contains more than one matching element
       at System.Linq.Enumerable.SingleOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
       at NServiceBus.RavenDB.Internal.DocumentIdConventions.MapTypeToCollectionName(Type type, CollectionData collectionData) in P:\NServiceBus.RavenDB\src\NServiceBus.RavenDB\Internal\DocumentIdConventions.cs:line 122
       at NServiceBus.RavenDB.Internal.DocumentIdConventions.Initialize() in P:\NServiceBus.RavenDB\src\NServiceBus.RavenDB\Internal\DocumentIdConventions.cs:line 71
       at NServiceBus.RavenDB.Internal.DocumentIdConventions.FindTypeTagName(Type type) in P:\NServiceBus.RavenDB\src\NServiceBus.RavenDB\Internal\DocumentIdConventions.cs:line 35
       at Raven.Client.Document.DocumentConvention.GetTypeTagName(Type type) in c:\Builds\RavenDB-Stable-3.0\Raven.Client.Lightweight\Document\DocumentConvention.cs:line 297
       at Raven.Client.Document.DocumentConvention.DefaultFindFullDocumentKeyFromNonStringIdentifier(Object id, Type type, Boolean allowNull) in c:\Builds\RavenDB-Stable-3.0\Raven.Client.Lightweight\Document\DocumentConvention.cs:line 153
       at Raven.Client.Document.DocumentSession.Load[T](ValueType id) in c:\Builds\RavenDB-Stable-3.0\Raven.Client.Lightweight\Document\DocumentSession.cs:line 309
       at NServiceBus.SagaPersisters.RavenDB.SagaPersister.Get[T](Guid sagaId) in P:\NServiceBus.RavenDB\src\NServiceBus.RavenDB\SagaPersister\SagaPersister.cs:line 66
       at NServiceBus.RavenDB.Tests.Persistence.DocumentIds.InconsistentSagaIdConventions.TestRetrievingSagas(ConventionType seedType) in P:\NServiceBus.RavenDB\src\NServiceBus.RavenDB.Tests\Persistence\DocumentIds\InconsistentSagaIdConventions.cs:line 48