### PR TITLE
Warn user if unsafe DTC settings are detected

### DIFF
--- a/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
@@ -66,22 +66,31 @@
             {
                 store.EnlistInDistributedTransactions = false;
             }
-            else if (store.JsonRequestFactory == null) // If the DocStore has not been initialized yet
+            else 
             {
-                // Source: https://github.com/ravendb/ravendb/blob/f56963f23f54b5535eba4f043fb84d5145b11b1d/Raven.Client.Lightweight/Document/DocumentStore.cs#L129
-                var ravenDefaultResourceManagerId = new Guid("e749baa6-6f76-4eef-a069-40a4378954f8");
-
-                if (store.ResourceManagerId == Guid.Empty || store.ResourceManagerId == ravenDefaultResourceManagerId)
+                if (store.JsonRequestFactory == null) // If the DocStore has not been initialized yet
                 {
-                    var resourceManagerId = settings.LocalAddress();
-                    store.ResourceManagerId = DeterministicGuidBuilder(resourceManagerId);
+                    if (store.ResourceManagerId == Guid.Empty || store.ResourceManagerId == ravenDefaultResourceManagerId)
+                    {
+                        var resourceManagerId = settings.LocalAddress();
+                        store.ResourceManagerId = DeterministicGuidBuilder(resourceManagerId);
+                    }
+
+                    // If using the default (Volatile - null should be impossible) then switch to IsolatedStorage
+                    // Leave alone if LocalDirectoryTransactionRecoveryStorage!
+                    if (store.TransactionRecoveryStorage == null || store.TransactionRecoveryStorage is VolatileOnlyTransactionRecoveryStorage)
+                    {
+                        store.TransactionRecoveryStorage = new IsolatedStorageTransactionRecoveryStorage();
+                    }
                 }
 
-                // If using the default (Volatile - null should be impossible) then switch to IsolatedStorage
-                // Leave alone if LocalDirectoryTransactionRecoveryStorage!
-                if (store.TransactionRecoveryStorage == null || store.TransactionRecoveryStorage is VolatileOnlyTransactionRecoveryStorage)
+                var dtcSettingsNotIdeal = store.ResourceManagerId == Guid.Empty ||
+                                          store.ResourceManagerId == ravenDefaultResourceManagerId ||
+                                          !(store.TransactionRecoveryStorage is LocalDirectoryTransactionRecoveryStorage);
+
+                if (dtcSettingsNotIdeal)
                 {
-                    store.TransactionRecoveryStorage = new IsolatedStorageTransactionRecoveryStorage();
+                    Logger.Warn("NServiceBus has detected that a RavenDB DocumentStore is being used with Distributed Transaction Coordinator transactions, but without the recommended production-safe settings for ResourceManagerId or TransactionStorageRecovery. Please refer to \"Setting RavenDB DTC settings manually\" in the NServiceBus documentation for more information.");
                 }
             }
         }
@@ -98,6 +107,8 @@
             }
         }
 
+        // Source: https://github.com/ravendb/ravendb/blob/f56963f23f54b5535eba4f043fb84d5145b11b1d/Raven.Client.Lightweight/Document/DocumentStore.cs#L129
+        static readonly Guid ravenDefaultResourceManagerId = new Guid("e749baa6-6f76-4eef-a069-40a4378954f8");
         Func<ReadOnlySettings, IDocumentStore> storeCreator;
         IDocumentStore docStore;
         bool isInitialized;


### PR DESCRIPTION
I think the most controversial part of this PR will be the warning message that is generated.

I know we don't want to link directly to doco for fear of broken links, so I referred to a title of an article that will exist once Particular/docs.particular.net#1496 is merged. Any better recommendation @SimonCropp?

@Particular/ravendb-persistence-maintainers please review.