### PR TITLE
v3.0.9 fails with System.InvalidOperationException : The Raven/DocumentsByEntityName index must exist in order to determine the document ID strategy.

### DIFF
--- a/src/NServiceBus.RavenDB.Tests/Persistence/DocumentIds/DocumentIdStrategyTests.cs
+++ b/src/NServiceBus.RavenDB.Tests/Persistence/DocumentIds/DocumentIdStrategyTests.cs
@@ -46,42 +46,5 @@
                 }
             }
         }
-
-        [Test]
-        public void EnsureMappingFailsWithoutIndex()
-        {
-            using (var db = new ReusableDB())
-            {
-
-                using (var store = db.NewStore())
-                {
-                    ApplyTestConventions(store, ConventionType.RavenDefault);
-                    store.Initialize();
-
-                    // Remove the index to make sure the conventions will throw
-                    store.DatabaseCommands.DeleteIndex("Raven/DocumentsByEntityName");
-
-                    var persister = new TimeoutPersister
-                    {
-                        DocumentStore = store,
-                        EndpointName = EndpointName
-                    };
-
-                    var exception = Assert.Throws<InvalidOperationException>(() =>
-                    {
-                        persister.Add(new TimeoutData
-                        {
-                            Destination = new Address(EndpointName, "localhost"),
-                            Headers = new Dictionary<string, string>(),
-                            OwningTimeoutManager = EndpointName,
-                            SagaId = Guid.NewGuid(),
-                            Time = DateTime.UtcNow
-                        });
-                    });
-
-                    Console.WriteLine($"Got expected Exception: {exception.Message}");
-                }
-            }
-        }
     }
 }

--- a/src/NServiceBus.RavenDB/Internal/DocumentIdConventions.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentIdConventions.cs
@@ -7,6 +7,7 @@
     using System.Text;
     using NServiceBus.Saga;
     using Raven.Client;
+    using Raven.Client.Indexes;
     using Raven.Json.Linq;
 
     class DocumentIdConventions
@@ -95,14 +96,10 @@
 
         private HashSet<string> GetTerms()
         {
-            const string DocsByEntityNameIndex = "Raven/DocumentsByEntityName";
-            var index = store.DatabaseCommands.GetIndex(DocsByEntityNameIndex);
-            if (index == null)
-            {
-                throw new InvalidOperationException("The Raven/DocumentsByEntityName index must exist in order to determine the document ID strategy. This index is created by RavenDB automatically. Please check in Raven Studio to make sure it exists.");
-            }
+            var index = new RavenDocumentsByEntityName();
+            store.ExecuteIndex(index);
 
-            var terms = store.DatabaseCommands.GetTerms(DocsByEntityNameIndex, "Tag", null, 1024);
+            var terms = store.DatabaseCommands.GetTerms(index.IndexName, "Tag", null, 1024);
             return new HashSet<string>(terms);
         }
 
@@ -184,8 +181,8 @@
 
         class CollectionData
         {
-            public HashSet<string> Collections { get; private set; } = new HashSet<string>();
-            public Dictionary<Type, string> Mappings { get; private set; } = new Dictionary<Type, string>();
+            public HashSet<string> Collections { get; } = new HashSet<string>();
+            public Dictionary<Type, string> Mappings { get; } = new Dictionary<Type, string>();
             public HashSet<string> IndexResults { get; set; }
             public bool Changed { get; set; }
         }

--- a/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Security.Cryptography;
     using System.Text;
-    using NServiceBus.Logging;
     using NServiceBus.Settings;
     using Raven.Client;
     using Raven.Client.Document;
@@ -11,8 +10,6 @@
 
     class DocumentStoreInitializer
     {
-        static readonly ILog Logger = LogManager.GetLogger(typeof(DocumentStoreInitializer));
-
         internal DocumentStoreInitializer(IDocumentStore store)
         {
             this.docStore = store;


### PR DESCRIPTION
Fixes #229