### PR TITLE
Changes for possible Beta 4

### DIFF
--- a/src/NServiceBus.RavenDB.AcceptanceTests/When_outbox_is_enabled.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/When_outbox_is_enabled.cs
@@ -72,17 +72,17 @@
 
             class DuplicateMessageHandler : IHandleMessages<DuplicateMessage>
             {
-                public async Task Handle(DuplicateMessage message, IMessageHandlerContext context)
+                public Task Handle(DuplicateMessage message, IMessageHandlerContext context)
                 {
-                    await context.Send(new DownstreamMessage());
+                    return context.Send(new DownstreamMessage());
                 }
             }
 
             class MarkerMessageHandler : IHandleMessages<MarkerMessage>
             {
-                public async Task Handle(MarkerMessage message, IMessageHandlerContext context)
+                public Task Handle(MarkerMessage message, IMessageHandlerContext context)
                 {
-                    await context.Send(message);
+                    return context.Send(message);
                 }
             }
         }

--- a/src/NServiceBus.RavenDB.AcceptanceTests/When_using_a_sagafinder.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/When_using_a_sagafinder.cs
@@ -45,14 +45,14 @@
             {
                 public Context Context { get; set; }
 
-                public async Task<SagaFinderSagaData> FindBy(StartSagaMessage message, SynchronizedStorageSession session, ReadOnlyContextBag options)
+                public Task<SagaFinderSagaData> FindBy(StartSagaMessage message, SynchronizedStorageSession session, ReadOnlyContextBag options)
                 {
                     if (Context.SagaId == Guid.Empty)
                     {
-                        return await Task.FromResult(default(SagaFinderSagaData));
+                        return Task.FromResult(default(SagaFinderSagaData));
                     }
 
-                    return await session.RavenSession().LoadAsync<SagaFinderSagaData>(Context.SagaId).ConfigureAwait(false);
+                    return session.RavenSession().LoadAsync<SagaFinderSagaData>(Context.SagaId);
                 }
             }
 

--- a/src/NServiceBus.RavenDB.Tests/API/APIApprovals.ApproveRavenDbPersistence.approved.txt
+++ b/src/NServiceBus.RavenDB.Tests/API/APIApprovals.ApproveRavenDbPersistence.approved.txt
@@ -21,6 +21,10 @@ namespace NServiceBus.Persistence.RavenDB
         public string DatabaseName { get; set; }
         public string Url { get; set; }
     }
+    public class static DocumentIdConventionsExtensions
+    {
+        public static NServiceBus.PersistenceExtentions<NServiceBus.RavenDBPersistence> DoNotUseLegacyConventionsWhichIsOnlySafeForNewEndpoints(this NServiceBus.PersistenceExtentions<NServiceBus.RavenDBPersistence> config) { }
+    }
     public interface IAsyncSessionProvider
     {
         Raven.Client.IAsyncDocumentSession AsyncSession { get; }

--- a/src/NServiceBus.RavenDB.Tests/Outbox/When_cleaning_outbox_messages.cs
+++ b/src/NServiceBus.RavenDB.Tests/Outbox/When_cleaning_outbox_messages.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.Extensibility;
     using NServiceBus.Outbox;
@@ -52,7 +51,7 @@
 
 
             await persister.SetAsDispatched(id, context);
-            Thread.Sleep(TimeSpan.FromSeconds(1)); //Need to wait for dispatch logic to finish
+            await Task.Delay(TimeSpan.FromSeconds(1)); //Need to wait for dispatch logic to finish
 
             //WaitForUserToContinueTheTest(store);
             WaitForIndexing(store);

--- a/src/NServiceBus.RavenDB.Tests/Persistence/DocumentIds/DocumentIdConventionTestBase.cs
+++ b/src/NServiceBus.RavenDB.Tests/Persistence/DocumentIds/DocumentIdConventionTestBase.cs
@@ -11,7 +11,7 @@
     {
         protected const string EndpointName = "FakeEndpoint";
 
-        protected async Task DirectStore(IDocumentStore store, string id, object document, string entityName)
+        protected Task DirectStore(IDocumentStore store, string id, object document, string entityName)
         {
             var jsonDoc = RavenJObject.FromObject(document);
             var metadata = new RavenJObject();
@@ -20,10 +20,10 @@
             metadata["Raven-Clr-Type"] = $"{type.FullName}, {type.Assembly.GetName().Name}";
 
             Console.WriteLine($"Creating {entityName}: {id}");
-            await store.AsyncDatabaseCommands.PutAsync(id, Etag.Empty, jsonDoc, metadata);
+            return store.AsyncDatabaseCommands.PutAsync(id, Etag.Empty, jsonDoc, metadata);
         }
 
-        protected async Task StoreHiLo(IDocumentStore store, string entityName)
+        protected Task StoreHiLo(IDocumentStore store, string entityName)
         {
             string hiloId = $"Raven/Hilo/{entityName}";
             var document = new RavenJObject();
@@ -31,7 +31,7 @@
             var metadata = new RavenJObject();
 
             Console.WriteLine($"Creating {hiloId}");
-            await store.AsyncDatabaseCommands.PutAsync(hiloId, null, document, metadata);
+            return store.AsyncDatabaseCommands.PutAsync(hiloId, null, document, metadata);
         }
 
         public enum ConventionType

--- a/src/NServiceBus.RavenDB.Tests/Timeouts/When_removing_timeouts_from_storage.cs
+++ b/src/NServiceBus.RavenDB.Tests/Timeouts/When_removing_timeouts_from_storage.cs
@@ -75,7 +75,7 @@
                 }
             });
 
-            Assert.IsTrue(t1.Result | t2.Result, "the document should be deleted");
+            Assert.IsTrue(await t1 | await t2, "the document should be deleted");
             Assert.IsFalse(t1.Result && t2.Result, "only one operation should complete successfully");
         }
 
@@ -116,7 +116,7 @@
                 }
             });
 
-            Assert.IsTrue(t1.Result | t2.Result, "the document should be deleted");
+            Assert.IsTrue(await t1 | await t2, "the document should be deleted");
             Assert.IsFalse(t1.Result && t2.Result, "only one operation should complete successfully");
         }
 

--- a/src/NServiceBus.RavenDB/Internal/DocumentIdConventions.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentIdConventions.cs
@@ -13,16 +13,20 @@
         private readonly IDocumentStore store;
         private readonly Func<Type, string> userSuppliedConventions;
         private readonly string endpointName;
+        private readonly bool sagasEnabled;
+        private readonly bool timeoutsEnabled;
         private readonly string collectionNamesDocId;
         private readonly object padlock;
         private Dictionary<Type, string> mappedTypes;
         private IEnumerable<Type> types;
 
-        public DocumentIdConventions(IDocumentStore store, IEnumerable<Type> types, string endpointName)
+        public DocumentIdConventions(IDocumentStore store, IEnumerable<Type> types, string endpointName, bool sagasEnabled = true, bool timeoutsEnabled = true)
         {
             this.store = store;
             this.types = types;
             this.endpointName = endpointName;
+            this.sagasEnabled = sagasEnabled;
+            this.timeoutsEnabled = timeoutsEnabled;
 
             collectionNamesDocId = $"NServiceBus/DocumentCollectionNames/{SHA1Hash(endpointName)}";
             userSuppliedConventions = store.Conventions.FindTypeTagName;
@@ -64,10 +68,16 @@
                     }
                 }
 
-                MapTypeToCollectionName(typeof(TimeoutPersisters.RavenDB.TimeoutData), collectionData);
-                foreach (var sagaType in types.Where(IsSagaEntity))
+                if (timeoutsEnabled)
                 {
-                    MapTypeToCollectionName(sagaType, collectionData);
+                    MapTypeToCollectionName(typeof(TimeoutPersisters.RavenDB.TimeoutData), collectionData);
+                }
+                if (sagasEnabled)
+                {
+                    foreach (var sagaType in types.Where(IsSagaEntity))
+                    {
+                        MapTypeToCollectionName(sagaType, collectionData);
+                    }
                 }
 
                 if (collectionData.Changed)

--- a/src/NServiceBus.RavenDB/Internal/DocumentIdConventions.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentIdConventions.cs
@@ -141,7 +141,7 @@
                     throw new InvalidOperationException($"Multiple RavenDB collection names ({options}) found for type `{type.FullName}`. Unable to determine DocumentId naming strategy for this type. Please remove or modify the documents that were mapped incorrectly.");
                 }
 
-                configuredName = collectionsThatExist.FirstOrDefault() ?? byLegacy;
+                configuredName = collectionsThatExist.FirstOrDefault() ?? ravenDefault;
                 collectionData.Collections.Add(configuredName);
                 collectionData.Changed = true;
             }

--- a/src/NServiceBus.RavenDB/Internal/DocumentIdConventionsExtensions.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentIdConventionsExtensions.cs
@@ -1,0 +1,29 @@
+﻿namespace NServiceBus.Persistence.RavenDB
+{
+    using NServiceBus.Configuration.AdvanceExtensibility;
+    using NServiceBus.Settings;
+
+    /// <summary>
+    /// This class provides advanced extension methods for RavenDB persistence configuration. 
+    /// </summary>
+    public static class DocumentIdConventionsExtensions
+    {
+        const string DoNotUseLegacyConventionsSettingsKey = "NServiceBus.RavenDB.DoNotUseLegacyConventions";
+
+        /// <summary>
+        /// Do not use legacy DocumentId mapping strategies from previous versions of NServiceBus.RavenDB.
+        /// This is a breaking change which, if applied to an existing database, will result in lost Saga and Timeout data.
+        /// Do not use this on an existing database under any circumstances.
+        /// </summary>
+        public static PersistenceExtentions<RavenDBPersistence> DoNotUseLegacyConventionsWhichIsOnlySafeForNewEndpoints(this PersistenceExtentions<RavenDBPersistence> config)
+        {
+            config.GetSettings().Set(DoNotUseLegacyConventionsSettingsKey, true);
+            return config;
+        }
+
+        internal static bool NeedToApplyDocumentIdConventionsToDocumentStore(ReadOnlySettings settings)
+        {
+            return settings.GetOrDefault<bool>(DoNotUseLegacyConventionsSettingsKey) == false;
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
@@ -53,10 +53,13 @@
 
         void ApplyConventions(ReadOnlySettings settings)
         {
-            var sagasEnabled = settings.IsFeatureActive(typeof(Sagas));
-            var timeoutsEnabled = settings.IsFeatureActive(typeof(TimeoutManager));
-            var idConventions = new DocumentIdConventions(docStore, settings.GetAvailableTypes(), settings.EndpointName().ToString(), sagasEnabled, timeoutsEnabled);
-            docStore.Conventions.FindTypeTagName = idConventions.FindTypeTagName;
+            if (DocumentIdConventionsExtensions.NeedToApplyDocumentIdConventionsToDocumentStore(settings))
+            {
+                var sagasEnabled = settings.IsFeatureActive(typeof(Sagas));
+                var timeoutsEnabled = settings.IsFeatureActive(typeof(TimeoutManager));
+                var idConventions = new DocumentIdConventions(docStore, settings.GetAvailableTypes(), settings.EndpointName().ToString(), sagasEnabled, timeoutsEnabled);
+                docStore.Conventions.FindTypeTagName = idConventions.FindTypeTagName;
+            }
 
             var store = docStore as DocumentStore;
             if (store == null)

--- a/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Security.Cryptography;
     using System.Text;
+    using NServiceBus.Features;
     using NServiceBus.Logging;
     using NServiceBus.Settings;
     using Raven.Client;
@@ -52,7 +53,9 @@
 
         void ApplyConventions(ReadOnlySettings settings)
         {
-            var idConventions = new DocumentIdConventions(docStore, settings.GetAvailableTypes(), settings.EndpointName().ToString());
+            var sagasEnabled = settings.IsFeatureActive(typeof(Sagas));
+            var timeoutsEnabled = settings.IsFeatureActive(typeof(TimeoutManager));
+            var idConventions = new DocumentIdConventions(docStore, settings.GetAvailableTypes(), settings.EndpointName().ToString(), sagasEnabled, timeoutsEnabled);
             docStore.Conventions.FindTypeTagName = idConventions.FindTypeTagName;
 
             var store = docStore as DocumentStore;

--- a/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
+++ b/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Internal\DocumentIdConventions.cs" />
     <Compile Include="Internal\DocumentStoreInitializer.cs" />
     <Compile Include="Internal\DocumentStoreManager.cs" />
+    <Compile Include="Internal\DocumentIdConventionsExtensions.cs" />
     <Compile Include="Internal\IDocumentStoreWrapper.cs" />
     <Compile Include="Internal\LegacyAddress.cs" />
     <Compile Include="Internal\BackwardsCompatibilityHelper.cs" />

--- a/src/NServiceBus.RavenDB/Outbox/OutboxPersister.cs
+++ b/src/NServiceBus.RavenDB/Outbox/OutboxPersister.cs
@@ -58,11 +58,11 @@
             return Task.FromResult<OutboxTransaction>(transaction);
         }
 
-        public async Task Store(OutboxMessage message, OutboxTransaction transaction, ContextBag context)
+        public Task Store(OutboxMessage message, OutboxTransaction transaction, ContextBag context)
         {
             var session = ((RavenDBOutboxTransaction)transaction).AsyncSession;
 
-            await session.StoreAsync(new OutboxRecord
+            return session.StoreAsync(new OutboxRecord
             {
                 MessageId = message.MessageId,
                 Dispatched = false,
@@ -73,7 +73,7 @@
                     MessageId = t.MessageId,
                     Options = t.Options
                 }).ToList()
-            }, GetOutboxRecordId(message.MessageId)).ConfigureAwait(false);
+            }, GetOutboxRecordId(message.MessageId));
         }
 
         public async Task SetAsDispatched(string messageId, ContextBag options)

--- a/src/NServiceBus.RavenDB/Outbox/RavenDBOutboxTransaction.cs
+++ b/src/NServiceBus.RavenDB/Outbox/RavenDBOutboxTransaction.cs
@@ -17,9 +17,9 @@
             AsyncSession = null;
         }
 
-        public async Task Commit()
+        public Task Commit()
         {
-            await AsyncSession.SaveChangesAsync().ConfigureAwait(false);
+            return AsyncSession.SaveChangesAsync();
         }
 
         public IAsyncDocumentSession AsyncSession { get; private set; }

--- a/src/NServiceBus.RavenDB/SagaPersister/SagaPersister.cs
+++ b/src/NServiceBus.RavenDB/SagaPersister/SagaPersister.cs
@@ -59,10 +59,10 @@ namespace NServiceBus.Persistence.RavenDB
             return TaskEx.CompletedTask;
         }
 
-        public async Task<T> Get<T>(Guid sagaId, SynchronizedStorageSession session, ContextBag context) where T : IContainSagaData
+        public Task<T> Get<T>(Guid sagaId, SynchronizedStorageSession session, ContextBag context) where T : IContainSagaData
         {
             var documentSession = session.RavenSession();
-            return await documentSession.LoadAsync<T>(sagaId).ConfigureAwait(false);
+            return documentSession.LoadAsync<T>(sagaId);
         }
 
         public async Task<T> Get<T>(string propertyName, object propertyValue, SynchronizedStorageSession session, ContextBag context) where T : IContainSagaData

--- a/utils/CleanDatabases.ps1
+++ b/utils/CleanDatabases.ps1
@@ -1,0 +1,26 @@
+$DatabaseUrl = "http://localhost:8083"
+$DatabasePath = "C:\RavenDBv3\Data"
+$WaitMinutes = 0
+$ignore = @( "system", "databases" )
+
+function TC-Write([string]$name) {
+	Write-Output "##teamcity[message text='$name']"
+}
+
+TC-Write "Running RavenDB Database Cleaner"
+TC-Write "RavenDB URL: $DatabaseUrl"
+TC-Write "RavenDB Data Path: $DatabasePath"
+
+$databases = Get-ChildItem $DatabasePath -Directory `
+| Where-Object { $ignore -notcontains $_.Name } `
+| Where-Object { $_.CreationTimeUtc -lt (([DateTime]::UtcNow).AddMinutes(-$WaitMinutes)) }
+
+
+foreach($database in $databases) {
+    TC-Write "Deleting $database"
+    $deleteUrl = "$($DatabaseUrl)/admin/databases/$([Uri]::EscapeDataString($database.Name))?hard-delete=true"
+    TC-Write "DELETE $deleteUrl"
+    Invoke-RestMethod $deleteUrl -Method Delete
+}
+
+Write-Host Completed


### PR DESCRIPTION
Connects to #229 

* Being applied to all backports:
  * Database cleanup script
  * Revert to raven default mapping when the database collection names do not already contain an opinion
  * If Saga/TimeoutManager features are not activated, do not map collection names for those types in conventions
* Async fixer mods brought in from #223 
* DoNotUseLegacyConventionsWhichIsOnlySafeForNewEndpoints, an advanced API mostly for ServiceControl (Will also be added to 3.2)

@Particular/ravendb-persistence-maintainers 