### PR TITLE
Remove LoggedExceptions usage

### DIFF
--- a/src/NServiceBus.RavenDB.AcceptanceTests/When_detecting_a_saga_with_multiple_corr_props.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/When_detecting_a_saga_with_multiple_corr_props.cs
@@ -1,9 +1,8 @@
 ﻿namespace NServiceBus.RavenDB.AcceptanceTests
 {
     using System;
-    using System.Linq;
     using System.Threading.Tasks;
-    using NServiceBus.AcceptanceTesting;
+    using AcceptanceTesting;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -19,7 +18,7 @@
             {
                 await Scenario.Define<Context>()
                     .WithEndpoint<MultiPropEndpoint>(e => e.DoNotFailOnErrorMessages())
-                    .Done(c => c.LoggedExceptions.Any() || c.EndpointsStarted)
+                    .Done(c => c.EndpointsStarted)
                     .Run();
             }
             catch (Exception ex)


### PR DESCRIPTION
https://github.com/Particular/NServiceBus/pull/3768 will remove the `LoggedExceptions` property from the context. It doesn't really seem to be needed here anyway since the test throws an exception when the endpoint is unable to start. Therefore removing it for easier upgrade to next beta version.