### PR TITLE
[WIP] Aligning OutboxRecord with TransportOperations to save allocations

### DIFF
--- a/src/NServiceBus.RavenDB/Outbox/OutboxRecord.cs
+++ b/src/NServiceBus.RavenDB/Outbox/OutboxRecord.cs
@@ -8,7 +8,7 @@
         public string MessageId { get; set; }
         public bool Dispatched { get; set; }
         public DateTime? DispatchedAt { get; set; }
-        public IList<OutboxOperation> TransportOperations { get; set; }
+        public OutboxOperation[] TransportOperations { get; set; }
 
         public class OutboxOperation
         {


### PR DESCRIPTION
Relates to https://github.com/Particular/NServiceBus/pull/3903

I aligned the `OutboxRecord` as well. According to Oren this is a non-breaking change.

See https://twitter.com/danielmarbach/status/750575811879632896