### PR TITLE
Use streaming query for V4 QueryTimeouts

### DIFF
--- a/src/NServiceBus.RavenDB.Tests/Timeouts/When_fetching_old_timeouts_from_storage.cs
+++ b/src/NServiceBus.RavenDB.Tests/Timeouts/When_fetching_old_timeouts_from_storage.cs
@@ -105,7 +105,7 @@
         public async Task Should_return_the_next_time_of_retrieval()
         {
             query.CleanupGapFromTimeslice = TimeSpan.FromSeconds(1);
-            query.TriggerCleanupEvery = TimeSpan.MinValue;
+            query.TriggerCleanupEvery = TimeSpan.Zero;
 
             var nextTime = DateTime.UtcNow.AddHours(1);
 

--- a/src/NServiceBus.RavenDB.Tests/Timeouts/When_fetching_timeouts_from_storage.cs
+++ b/src/NServiceBus.RavenDB.Tests/Timeouts/When_fetching_timeouts_from_storage.cs
@@ -59,7 +59,7 @@
         public async Task Should_return_the_next_time_of_retrieval()
         {
             query.CleanupGapFromTimeslice = TimeSpan.FromSeconds(1);
-            query.TriggerCleanupEvery = TimeSpan.MinValue;
+            query.TriggerCleanupEvery = TimeSpan.Zero;
 
             var nextTime = DateTime.UtcNow.AddHours(1);
             var context = new ContextBag();

--- a/src/NServiceBus.RavenDB/Timeouts/QueryTimeouts.cs
+++ b/src/NServiceBus.RavenDB/Timeouts/QueryTimeouts.cs
@@ -27,8 +27,26 @@ namespace NServiceBus.Persistence.RavenDB
             logger = LogManager.GetLogger<QueryTimeouts>();
         }
 
-        public TimeSpan CleanupGapFromTimeslice { get; set; }
-        public TimeSpan TriggerCleanupEvery { get; set; }
+        public TimeSpan CleanupGapFromTimeslice
+        {
+            get { return _cleanupGapFromTimeslice; }
+            set
+            {
+                if (value < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(CleanupGapFromTimeslice));
+                _cleanupGapFromTimeslice = value;
+            }
+        }
+
+        public TimeSpan TriggerCleanupEvery
+        {
+            get { return _triggerCleanupEvery; }
+            set
+            {
+                if (value < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(TriggerCleanupEvery));
+                _triggerCleanupEvery = value;
+            }
+        }
+
         public Func<DateTime> GetUtcNow { get; set; } = () => DateTime.UtcNow;
 
         public async Task<TimeoutsChunk> GetNextChunk(DateTime startSlice)
@@ -167,8 +185,10 @@ namespace NServiceBus.Persistence.RavenDB
         /// <summary>
         /// RavenDB server default maximum page size 
         /// </summary>
-        private int maximumPageSize = 1024;
+        int maximumPageSize = 1024;
         CancellationTokenSource shutdownTokenSource;
         ILog logger;
+        TimeSpan _triggerCleanupEvery;
+        TimeSpan _cleanupGapFromTimeslice;
     }
 }


### PR DESCRIPTION
@Particular/ravendb-persistence-maintainers please review.

One interesting thing is I had a test run where I missed a timeout in persistence that should have been handled by cleanup. It was using the slice time (so timeouts 2 minutes old from the slice time) except if you have no more timeouts coming in, the slice time never changes! Therefore, I changed to have the cleanup do its math based on **now**.