### PR TITLE
Outbox operations null

### DIFF
--- a/src/NServiceBus.RavenDB/Outbox/OutboxPersister.cs
+++ b/src/NServiceBus.RavenDB/Outbox/OutboxPersister.cs
@@ -105,6 +105,7 @@
 
                 outboxMessage.Dispatched = true;
                 outboxMessage.DispatchedAt = DateTime.UtcNow;
+                outboxMessage.TransportOperations = emptyOutboxOperations;
 
                 await session.SaveChangesAsync().ConfigureAwait(false);
             }
@@ -124,5 +125,6 @@
         string endpointName;
         IDocumentStore documentStore;
         TransportOperation[] emptyTransportOperations = new TransportOperation[0];
+        OutboxRecord.OutboxOperation[] emptyOutboxOperations = new OutboxRecord.OutboxOperation[0];
     }
 }


### PR DESCRIPTION
Currently targets master since I think that is something we can potentially release as a patch (not hotfix though). Feel free to retarget

NHibernate nullifies the outbox operations when the record is marked as dispatched

https://github.com/Particular/NServiceBus.NHibernate/blob/master/src/NServiceBus.NHibernate/Outbox/OutboxPersister.cs#L96

This caused some confusion when a customer was migrating from RavenDB to NHibernate persistence. I think it is worth aligning since it also "frees" up the storage dramatically.

Thoughts @Particular/ravendb-persistence-maintainers ?