### PR TITLE
Outbox operations null on 3.x

### DIFF
--- a/packaging/nuget/nservicebus.ravendb.nuspec
+++ b/packaging/nuget/nservicebus.ravendb.nuspec
@@ -16,7 +16,7 @@
     <tags>nservicebus servicebus msmq cqrs publish subscribe ravendb</tags>
     <dependencies>
       <dependency id="NServiceBus" version="[5.2.8, 6.0.0)" />
-      <dependency id="RavenDB.Client" version="[3.0.3800, 4.0.0)" />
+      <dependency id="RavenDB.Client" version="[3.0.3800, 3.1.0)" />
     </dependencies>
   </metadata>
   <files>

--- a/src/NServiceBus.RavenDB/Outbox/OutboxPersister.cs
+++ b/src/NServiceBus.RavenDB/Outbox/OutboxPersister.cs
@@ -79,12 +79,14 @@
 
                 outboxMessage.Dispatched = true;
                 outboxMessage.DispatchedAt = DateTime.UtcNow;
+                outboxMessage.TransportOperations = emptyOutboxOperations;
 
                 session.SaveChanges();
             }
         }
 
         static string GetOutboxRecordIdWithoutEndpointName(string messageId) => $"Outbox/{messageId}";
+        OutboxRecord.OutboxOperation[] emptyOutboxOperations = new OutboxRecord.OutboxOperation[0];
 
         string GetOutboxRecordId(string messageId) => $"Outbox/{EndpointName}/{messageId}";
     }


### PR DESCRIPTION
This is the boackport to 3.x of the improvement proposed by @danielmarbach in #302 

Included in this PR:
- When the outbox message is set as dispatched transport operations are set to a empty array, reducing storage needs and to align the behavior with the one of other persisters
- Adjusted nuspec dependencies range to prevent users to upgrade RavenDB Client to 3.5 that contains a breaking change (details: https://github.com/Particular/NServiceBus.RavenDB/issues/300)

@Particular/ravendb-persistence-maintainers please review.