### PR TITLE
Outbox persister may fail if handling non-CombGuid message id

### DIFF
--- a/src/NServiceBus.RavenDB.Tests/Persistence/DocumentIds/DocumentIdConventionTestBase.cs
+++ b/src/NServiceBus.RavenDB.Tests/Persistence/DocumentIds/DocumentIdConventionTestBase.cs
@@ -25,7 +25,7 @@
 
         protected Task StoreHiLo(IDocumentStore store, string entityName)
         {
-            string hiloId = $"Raven/Hilo/{entityName}";
+            var hiloId = $"Raven/Hilo/{entityName}";
             var document = new RavenJObject();
             document["Max"] = 32;
             var metadata = new RavenJObject();

--- a/src/NServiceBus.RavenDB/Outbox/OutboxPersister.cs
+++ b/src/NServiceBus.RavenDB/Outbox/OutboxPersister.cs
@@ -115,12 +115,14 @@
         {
             return new[]
             {
+                // Current format, already replaces \ with _
                 GetOutboxRecordId(messageId),
-                $"Outbox/{messageId}"
+                // Legacy format without endpoint id
+                $"Outbox/{messageId.Replace('\\', '_')}"
             };
         }
 
-        string GetOutboxRecordId(string messageId) => $"Outbox/{endpointName}/{messageId}";
+        string GetOutboxRecordId(string messageId) => $"Outbox/{endpointName}/{messageId.Replace('\\', '_')}";
 
         string endpointName;
         IDocumentStore documentStore;


### PR DESCRIPTION
Connects to https://github.com/Particular/NServiceBus.RavenDB/issues/313

Discovered that for subscription messages, NServiceBus is not assigning a CombGuid message id, and so the transport-native message id ends up getting used for Outbox instead. In the case of MSMQ, the transport-native id is in the form of `{Guid}\{Integer}` and is rejected by RavenDB due to the URL-incompatible `\` character.

Although subscription messages should still have standard CombGuid ids (https://github.com/Particular/NServiceBus/issues/4709) and it's dubious whether control messages should go through the Outbox at all (https://github.com/Particular/NServiceBus/issues/4710) we need to change the Outbox persister to gracefully handle these characters by using character replacement.

### Who's affected

Customers using MSMQ with RavenDB persistence that have also enabled the Outbox and are using Publish/Subscribe are known to be affected because of the MSMQ native message identifiers generated by NServiceBus for subscription messages.

### Symptoms

When a subscription message is received, processing it through the RavenDB Outbox will not succeed because of a `\` character in the subscription message's id, which is incompatible with RavenDB document naming rules. The subscription message will fail to process and be sent to the error queue.

### Backported to

The fix is backported to the following releases:

* 4.1.3 - for RavenDB 3.5 on NServiceBus 6.x
* 4.0.3 - for RavenDB 3.0 on NServiceBus 6.x
* 3.2.1 - for RavenDB 3.5 on NServiceBus 5.x
* 3.0.15 - for RavenDB 3.0 on NServiceBus 5.x