### PR TITLE
Allow to store subscriptions ignoring the message version (via strategy)

### DIFF
--- a/src/NServiceBus.RavenDB.Tests/API/APIApprovals.ApproveRavenDbPersistence.approved.txt
+++ b/src/NServiceBus.RavenDB.Tests/API/APIApprovals.ApproveRavenDbPersistence.approved.txt
@@ -85,7 +85,7 @@ namespace NServiceBus
     public class static RavenDbSubscriptionSettingsExtensions
     {
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> CacheSubscriptionsFor(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.TimeSpan aggressiveCacheDuration) { }
-        public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> DisableSubscriptionsVersioning(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg) { }
+        public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> DisableSubscriptionVersioning(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> DoNotCacheSubscriptions(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForSubscriptions(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, Raven.Client.IDocumentStore documentStore) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForSubscriptions(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.Settings.ReadOnlySettings, Raven.Client.IDocumentStore> storeCreator) { }

--- a/src/NServiceBus.RavenDB.Tests/API/APIApprovals.ApproveRavenDbPersistence.approved.txt
+++ b/src/NServiceBus.RavenDB.Tests/API/APIApprovals.ApproveRavenDbPersistence.approved.txt
@@ -85,6 +85,7 @@ namespace NServiceBus
     public class static RavenDbSubscriptionSettingsExtensions
     {
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> CacheSubscriptionsFor(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.TimeSpan aggressiveCacheDuration) { }
+        public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> DisableSubscriptionsVersioning(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> DoNotCacheSubscriptions(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForSubscriptions(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, Raven.Client.IDocumentStore documentStore) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForSubscriptions(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.Settings.ReadOnlySettings, Raven.Client.IDocumentStore> storeCreator) { }

--- a/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
+++ b/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
@@ -27,6 +27,7 @@
     <Prefer32Bit>false</Prefer32Bit>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseVSHostingProcess>false</UseVSHostingProcess>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -81,9 +82,9 @@
       <HintPath>..\packages\NServiceBus.6.1.2\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+    <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Raven.Abstractions, Version=3.5.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
       <HintPath>..\packages\RavenDB.Tests.Helpers.3.5.0\lib\net45\Raven.Abstractions.dll</HintPath>
@@ -134,6 +135,7 @@
     <Compile Include="App_Packages\ApiApprover.3.0.1\PublicApiApprover.cs" />
     <Compile Include="App_Packages\ApiApprover.3.0.1\PublicApiGenerator.cs" />
     <Compile Include="SubscriptionStorage\SubscriptionClientTests.cs" />
+    <Compile Include="SubscriptionStorage\When_receiving_multiple_subscription_messages_with_defferent_versions.cs" />
     <Compile Include="TestConstants.cs" />
     <Compile Include="FakeRavenDBTestTransport.cs" />
     <Compile Include="Infrastructure\ReusableDB.cs" />

--- a/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
+++ b/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
@@ -135,7 +135,7 @@
     <Compile Include="App_Packages\ApiApprover.3.0.1\PublicApiApprover.cs" />
     <Compile Include="App_Packages\ApiApprover.3.0.1\PublicApiGenerator.cs" />
     <Compile Include="SubscriptionStorage\SubscriptionClientTests.cs" />
-    <Compile Include="SubscriptionStorage\When_receiving_multiple_subscription_messages_with_defferent_versions.cs" />
+    <Compile Include="SubscriptionStorage\When_subscriptions_versioning_is_disabled.cs" />
     <Compile Include="TestConstants.cs" />
     <Compile Include="FakeRavenDBTestTransport.cs" />
     <Compile Include="Infrastructure\ReusableDB.cs" />

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_converting_old_subscription_to_new_subscription.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_converting_old_subscription_to_new_subscription.cs
@@ -41,7 +41,7 @@
                     new LegacyAddress("mytestendpoint", RuntimeEnvironment.MachineName)
                 },
                 MessageType = messageType
-            }, Subscription.FormatId(messageType))
+            }, new VersionedSubscriptionIdFormatter().FormatId(messageType))
             .ConfigureAwait(false);
             await session.SaveChangesAsync().ConfigureAwait(false);
 
@@ -72,7 +72,7 @@
                     new LegacyAddress("mytestendpoint", null)
                 },
                 MessageType = messageType
-            }, Subscription.FormatId(messageType)).ConfigureAwait(false);
+            }, new VersionedSubscriptionIdFormatter().FormatId(messageType)).ConfigureAwait(false);
             await session.SaveChangesAsync().ConfigureAwait(false);
 
             List<Subscriber> subscriptions = null;
@@ -98,7 +98,7 @@
             {
                 Clients = new List<LegacyAddress>(),
                 MessageType = messageType
-            }, Subscription.FormatId(messageType)).ConfigureAwait(false);
+            }, new VersionedSubscriptionIdFormatter().FormatId(messageType)).ConfigureAwait(false);
             await session.SaveChangesAsync().ConfigureAwait(false);
 
             List<Subscriber> subscriptions = null;
@@ -121,7 +121,7 @@
                     new SubscriptionClient { TransportAddress = "mytestendpoint" + "@" + RuntimeEnvironment.MachineName, Endpoint = "mytestendpoint" }
                 },
                 MessageType = messageType
-            }, Subscription.FormatId(messageType)).ConfigureAwait(false);
+            }, new VersionedSubscriptionIdFormatter().FormatId(messageType)).ConfigureAwait(false);
 
             await session.SaveChangesAsync().ConfigureAwait(false);
 
@@ -142,7 +142,7 @@
                     new LegacyAddress("mytestendpoint", RuntimeEnvironment.MachineName)
                 },
                 MessageType = MessageTypes.MessageA
-            }, Subscription.FormatId(MessageTypes.MessageA))
+            }, new VersionedSubscriptionIdFormatter().FormatId(MessageTypes.MessageA))
             .ConfigureAwait(false);
             await session.SaveChangesAsync().ConfigureAwait(false);
 

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_multiple_subscription_messages_with_defferent_versions.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_multiple_subscription_messages_with_defferent_versions.cs
@@ -1,0 +1,48 @@
+using System.Linq;
+using System.Threading.Tasks;
+using NServiceBus.Extensibility;
+using NServiceBus.Persistence.RavenDB;
+using NServiceBus.RavenDB.Persistence.SubscriptionStorage;
+using NServiceBus.RavenDB.Tests;
+using NServiceBus.Unicast.Subscriptions;
+using NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions;
+using NUnit.Framework;
+using Raven.Client;
+
+[TestFixture]
+public class When_subscriptions_versioning_is_disabled : RavenDBPersistenceTestBase
+{
+    [Test]
+    public async Task should_ignore_message_version()
+    {
+        var subscriberAddress_v1 = "v1@localhost";
+        var subscriberAddress_v2 = "v2@localhost";
+        var messageType_v1 = new MessageType("SomeMessageType", "1.0.0.0");
+        var messageType_v2 = new MessageType("SomeMessageType", "2.0.0.0");
+        var subscriber_v1 = new Subscriber(subscriberAddress_v1, "some_endpoint_name");
+        var subscriber_v2 = new Subscriber(subscriberAddress_v2, "another_endpoint_name");
+
+        var storage = new SubscriptionPersister(store)
+        {
+            DisableSubscriptionsVersioning = true
+        };
+
+        await storage.Subscribe(subscriber_v1, messageType_v1, new ContextBag());
+        await storage.Subscribe(subscriber_v2, messageType_v2, new ContextBag());
+ 
+        var subscribers_looked_up_by_v1 = (await storage.GetSubscriberAddressesForMessage(new[]
+        {
+            messageType_v1
+        }, new ContextBag())).ToArray();
+
+        var subscribers_looked_up_by_v2 = (await storage.GetSubscriberAddressesForMessage(new[]
+        {
+            messageType_v2
+        }, new ContextBag())).ToArray();
+
+        Assert.AreEqual(2, subscribers_looked_up_by_v1.Length);
+        Assert.AreEqual(2, subscribers_looked_up_by_v2.Length);
+        //Assert.AreEqual(subscriberAddress, subscribers[0].TransportAddress);
+        //Assert.AreEqual("new_endpoint_name", subscribers[0].Endpoint);
+    }
+}

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_subscriptions_versioning_is_disabled.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_subscriptions_versioning_is_disabled.cs
@@ -6,6 +6,7 @@ using NServiceBus.RavenDB.Tests;
 using NServiceBus.Unicast.Subscriptions;
 using NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions;
 using NUnit.Framework;
+using NServiceBus.RavenDB.Persistence.SubscriptionStorage;
 
 [TestFixture]
 public class When_subscriptions_versioning_is_disabled : RavenDBPersistenceTestBase
@@ -22,7 +23,7 @@ public class When_subscriptions_versioning_is_disabled : RavenDBPersistenceTestB
 
         var storage = new SubscriptionPersister(store)
         {
-            DisableSubscriptionsVersioning = true
+            SubscriptionIdFormatter = new NonVersionedSubscriptionIdFormatter()
         };
 
         await storage.Subscribe(subscriber_v1, messageType_v1, new ContextBag());
@@ -54,7 +55,7 @@ public class When_subscriptions_versioning_is_disabled : RavenDBPersistenceTestB
 
         var storage = new SubscriptionPersister(store)
         {
-            DisableSubscriptionsVersioning = true
+            SubscriptionIdFormatter = new NonVersionedSubscriptionIdFormatter()
         };
 
         await storage.Subscribe(subscriber_v1, messageType_v1, new ContextBag());

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_subscriptions_versioning_is_disabled.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_subscriptions_versioning_is_disabled.cs
@@ -58,13 +58,21 @@ public class When_subscriptions_versioning_is_disabled : RavenDBPersistenceTestB
         };
 
         await storage.Subscribe(subscriber_v1, messageType_v1, new ContextBag());
-        await storage.Unsubscribe(subscriber_v2, messageType_v2, new ContextBag());
 
         var subscribers = (await storage.GetSubscriberAddressesForMessage(new[]
         {
             messageType_v1
         }, new ContextBag())).ToArray();
 
-        Assert.AreEqual(0, subscribers.Length);
+        Assert.AreEqual(1, subscribers.Length);
+
+        await storage.Unsubscribe(subscriber_v2, messageType_v2, new ContextBag());
+
+        var subscribers_looked_up_by_v1 = (await storage.GetSubscriberAddressesForMessage(new[]
+        {
+            messageType_v1
+        }, new ContextBag())).ToArray();
+
+        Assert.AreEqual(0, subscribers_looked_up_by_v1.Length);
     }
 }

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_subscriptions_versioning_is_disabled.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_subscriptions_versioning_is_disabled.cs
@@ -2,12 +2,10 @@ using System.Linq;
 using System.Threading.Tasks;
 using NServiceBus.Extensibility;
 using NServiceBus.Persistence.RavenDB;
-using NServiceBus.RavenDB.Persistence.SubscriptionStorage;
 using NServiceBus.RavenDB.Tests;
 using NServiceBus.Unicast.Subscriptions;
 using NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions;
 using NUnit.Framework;
-using Raven.Client;
 
 [TestFixture]
 public class When_subscriptions_versioning_is_disabled : RavenDBPersistenceTestBase
@@ -42,7 +40,5 @@ public class When_subscriptions_versioning_is_disabled : RavenDBPersistenceTestB
 
         Assert.AreEqual(2, subscribers_looked_up_by_v1.Length);
         Assert.AreEqual(2, subscribers_looked_up_by_v2.Length);
-        //Assert.AreEqual(subscriberAddress, subscribers[0].TransportAddress);
-        //Assert.AreEqual("new_endpoint_name", subscribers[0].Endpoint);
     }
 }

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_using_subscription_converter.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_using_subscription_converter.cs
@@ -30,7 +30,7 @@ namespace NServiceBus.RavenDB.Tests.SubscriptionStorage
 
             persister = new SubscriptionPersister(store);
             msgType = new MessageType(typeof(MessageA));
-            docId = Subscription.FormatId(msgType);
+            docId = new VersionedSubscriptionIdFormatter().FormatId(msgType);
         }
 
         [Test]

--- a/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
+++ b/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
@@ -116,6 +116,9 @@
     <Compile Include="SagaPersister\SagaPersister.cs" />
     <Compile Include="SagaPersister\SagaUniqueIdentity.cs" />
     <Compile Include="SessionManagement\RavenSessionExtension.cs" />
+    <Compile Include="Subscriptions\ISubscriptionIdFormatter.cs" />
+    <Compile Include="Subscriptions\NonVersionedSubscriptionIdFormatter.cs" />
+    <Compile Include="Subscriptions\VersionedSubscriptionIdFormatter.cs" />
     <Compile Include="Subscriptions\MessageTypeConverter.cs" />
     <Compile Include="Subscriptions\RavenDbSubscriptionSettingsExtensions.cs" />
     <Compile Include="Subscriptions\RavenDbSubscriptionStorage.cs" />

--- a/src/NServiceBus.RavenDB/Subscriptions/ISubscriptionIdFormatter.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/ISubscriptionIdFormatter.cs
@@ -1,0 +1,9 @@
+﻿namespace NServiceBus.RavenDB.Persistence.SubscriptionStorage
+{
+    using NServiceBus.Unicast.Subscriptions;
+
+    internal interface ISubscriptionIdFormatter
+    {
+        string FormatId(MessageType messageType);
+    }
+}

--- a/src/NServiceBus.RavenDB/Subscriptions/NonVersionedSubscriptionIdFormatter.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/NonVersionedSubscriptionIdFormatter.cs
@@ -1,0 +1,24 @@
+﻿namespace NServiceBus.RavenDB.Persistence.SubscriptionStorage
+{
+    using System;
+    using System.Security.Cryptography;
+    using System.Text;
+    using Unicast.Subscriptions;
+
+    class NonVersionedSubscriptionIdFormatter : ISubscriptionIdFormatter
+    {
+        public string FormatId(MessageType messageType)
+        {
+            // use MD5 hash to get a 16-byte hash of the string
+            using (var provider = new MD5CryptoServiceProvider())
+            {
+                var inputBytes = Encoding.Default.GetBytes(messageType.TypeName);
+                var hashBytes = provider.ComputeHash(inputBytes);
+                // generate a guid from the hash:
+                var id = new Guid(hashBytes);
+
+                return $"Subscriptions/{id}";
+            }
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionSettingsExtensions.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionSettingsExtensions.cs
@@ -65,9 +65,9 @@
         }
 
         /// <summary>
-        /// Stop using message versions to store subscriptions. By default RavenDB Persistence subscriptions storage format includes
-        /// the message version, by enabling this setting the storage will store subscription using the message type as subscription key
-        /// simplifying the evolution of large systems where message assembly versioning is required.
+        /// Do not include message assembly major version in subscription document lookup key.
+        /// Subscription behavior will be changed such that all existing subscriptions will be rendered invalid.
+        /// Do not enable in an existing system without converting subscription documents first.
         /// </summary>
         /// <param name="cfg"></param>
         /// <returns></returns>

--- a/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionSettingsExtensions.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionSettingsExtensions.cs
@@ -14,6 +14,7 @@
     {
         internal const string DoNotAggressivelyCacheSubscriptionsSettingsKey = "RavenDB.DoNotAggressivelyCacheSubscriptions";
         internal const string AggressiveCacheDurationSettingsKey = "RavenDB.AggressiveCacheDuration";
+        internal const string DisableSubscriptionsVersioningKey = "RavenDB.DisableSubscriptionsVersioning";
 
         /// <summary>
         ///     Configures the given document store to be used when storing subscriptions
@@ -60,6 +61,19 @@
         public static PersistenceExtensions<RavenDBPersistence> CacheSubscriptionsFor(this PersistenceExtensions<RavenDBPersistence> cfg, TimeSpan aggressiveCacheDuration)
         {
             cfg.GetSettings().Set(AggressiveCacheDurationSettingsKey, aggressiveCacheDuration);
+            return cfg;
+        }
+
+        /// <summary>
+        /// Stop using message versions to store subscriptions. By default RavenDB Persistence subscriptions storage format includes
+        /// the message version, by enabling this setting the storage will store subscription using the message type as subscription key
+        /// simplifying the evolution of large systems where message assembly versioning is required.
+        /// </summary>
+        /// <param name="cfg"></param>
+        /// <returns></returns>
+        public static PersistenceExtensions<RavenDBPersistence> DisableSubscriptionsVersioning(this PersistenceExtensions<RavenDBPersistence> cfg)
+        {
+            cfg.GetSettings().Set(DisableSubscriptionsVersioningKey, true);
             return cfg;
         }
     }

--- a/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionSettingsExtensions.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionSettingsExtensions.cs
@@ -14,7 +14,7 @@
     {
         internal const string DoNotAggressivelyCacheSubscriptionsSettingsKey = "RavenDB.DoNotAggressivelyCacheSubscriptions";
         internal const string AggressiveCacheDurationSettingsKey = "RavenDB.AggressiveCacheDuration";
-        internal const string DisableSubscriptionsVersioningKey = "RavenDB.DisableSubscriptionsVersioning";
+        internal const string DisableSubscriptionVersioningKey = "RavenDB.DisableSubscriptionVersioning";
 
         /// <summary>
         ///     Configures the given document store to be used when storing subscriptions
@@ -71,9 +71,9 @@
         /// </summary>
         /// <param name="cfg"></param>
         /// <returns></returns>
-        public static PersistenceExtensions<RavenDBPersistence> DisableSubscriptionsVersioning(this PersistenceExtensions<RavenDBPersistence> cfg)
+        public static PersistenceExtensions<RavenDBPersistence> DisableSubscriptionVersioning(this PersistenceExtensions<RavenDBPersistence> cfg)
         {
-            cfg.GetSettings().Set(DisableSubscriptionsVersioningKey, true);
+            cfg.GetSettings().Set(DisableSubscriptionVersioningKey, true);
             return cfg;
         }
     }

--- a/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionStorage.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionStorage.cs
@@ -4,6 +4,7 @@
     using NServiceBus.Features;
     using NServiceBus.Persistence;
     using NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions;
+    using NServiceBus.RavenDB.Persistence.SubscriptionStorage;
 
     class RavenDbSubscriptionStorage : Feature
     {
@@ -27,7 +28,7 @@
 
             if (context.Settings.GetOrDefault<bool>(RavenDbSubscriptionSettingsExtensions.DisableSubscriptionsVersioningKey))
             {
-                persister.DisableSubscriptionsVersioning = true;
+                persister.SubscriptionIdFormatter = new NonVersionedSubscriptionIdFormatter();
             }
 
             TimeSpan aggressiveCacheDuration;

--- a/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionStorage.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionStorage.cs
@@ -25,6 +25,11 @@
                 persister.DisableAggressiveCaching = true;
             }
 
+            if (context.Settings.GetOrDefault<bool>(RavenDbSubscriptionSettingsExtensions.DisableSubscriptionsVersioningKey))
+            {
+                persister.DisableSubscriptionsVersioning = true;
+            }
+
             TimeSpan aggressiveCacheDuration;
             if (context.Settings.TryGet(RavenDbSubscriptionSettingsExtensions.AggressiveCacheDurationSettingsKey, out aggressiveCacheDuration))
             {

--- a/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionStorage.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionStorage.cs
@@ -26,7 +26,7 @@
                 persister.DisableAggressiveCaching = true;
             }
 
-            if (context.Settings.GetOrDefault<bool>(RavenDbSubscriptionSettingsExtensions.DisableSubscriptionsVersioningKey))
+            if (context.Settings.GetOrDefault<bool>(RavenDbSubscriptionSettingsExtensions.DisableSubscriptionVersioningKey))
             {
                 persister.SubscriptionIdFormatter = new NonVersionedSubscriptionIdFormatter();
             }

--- a/src/NServiceBus.RavenDB/Subscriptions/Subscription.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/Subscription.cs
@@ -45,12 +45,16 @@ namespace NServiceBus.RavenDB.Persistence.SubscriptionStorage
             }
         }
 
-        public static string FormatId(MessageType messageType)
+        //setting doNotUseVersionInSubscriptionId top false as it's the default behavior
+        public static string FormatId(MessageType messageType, bool doNotUseVersionInSubscriptionId = false)
         {
             // use MD5 hash to get a 16-byte hash of the string
             using (var provider = new MD5CryptoServiceProvider())
             {
-                var inputBytes = Encoding.Default.GetBytes(messageType.TypeName + "/" + messageType.Version.Major);
+                var inputString = doNotUseVersionInSubscriptionId ?
+                    messageType.TypeName
+                    : messageType.TypeName + "/" + messageType.Version.Major;
+                var inputBytes = Encoding.Default.GetBytes(inputString);
                 var hashBytes = provider.ComputeHash(inputBytes);
                 // generate a guid from the hash:
                 var id = new Guid(hashBytes);

--- a/src/NServiceBus.RavenDB/Subscriptions/Subscription.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/Subscription.cs
@@ -1,12 +1,9 @@
 namespace NServiceBus.RavenDB.Persistence.SubscriptionStorage
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Security.Cryptography;
-    using System.Text;
     using NServiceBus.Persistence.RavenDB;
     using NServiceBus.Unicast.Subscriptions;
     using Raven.Imports.Newtonsoft.Json;
+    using System.Collections.Generic;
 
     class Subscription
     {
@@ -42,24 +39,6 @@ namespace NServiceBus.RavenDB.Persistence.SubscriptionStorage
                     legacySubscriptions = new List<LegacyAddress>();
                 }
                 return legacySubscriptions;
-            }
-        }
-
-        //setting doNotUseVersionInSubscriptionId top false as it's the default behavior
-        public static string FormatId(MessageType messageType, bool doNotUseVersionInSubscriptionId = false)
-        {
-            // use MD5 hash to get a 16-byte hash of the string
-            using (var provider = new MD5CryptoServiceProvider())
-            {
-                var inputString = doNotUseVersionInSubscriptionId ?
-                    messageType.TypeName
-                    : messageType.TypeName + "/" + messageType.Version.Major;
-                var inputBytes = Encoding.Default.GetBytes(inputString);
-                var hashBytes = provider.ComputeHash(inputBytes);
-                // generate a guid from the hash:
-                var id = new Guid(hashBytes);
-
-                return $"Subscriptions/{id}";
             }
         }
     }

--- a/src/NServiceBus.RavenDB/Subscriptions/SubscriptionPersister.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/SubscriptionPersister.cs
@@ -21,6 +21,7 @@ namespace NServiceBus.Persistence.RavenDB
 
         public TimeSpan AggressiveCacheDuration { get; set; } = TimeSpan.FromMinutes(1);
         public bool DisableAggressiveCaching { get; set; }
+        public bool DisableSubscriptionsVersioning { get; set; }
 
         public async Task Subscribe(Subscriber subscriber, MessageType messageType, ContextBag context)
         {
@@ -38,7 +39,7 @@ namespace NServiceBus.Persistence.RavenDB
                 {
                     using (var session = OpenAsyncSession())
                     {
-                        var subscriptionDocId = Subscription.FormatId(messageType);
+                        var subscriptionDocId = Subscription.FormatId(messageType, DisableSubscriptionsVersioning);
 
                         var subscription = await session.LoadAsync<Subscription>(subscriptionDocId).ConfigureAwait(false);
 
@@ -85,7 +86,7 @@ namespace NServiceBus.Persistence.RavenDB
 
             using (var session = OpenAsyncSession())
             {
-                var subscriptionDocId = Subscription.FormatId(messageType);
+                var subscriptionDocId = Subscription.FormatId(messageType, DisableSubscriptionsVersioning);
 
                 var subscription = await session.LoadAsync<Subscription>(subscriptionDocId).ConfigureAwait(false);
 
@@ -105,7 +106,7 @@ namespace NServiceBus.Persistence.RavenDB
 
         public async Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes, ContextBag context)
         {
-            var ids = messageTypes.Select(Subscription.FormatId).ToList();
+            var ids = messageTypes.Select(messageType => Subscription.FormatId(messageType, DisableSubscriptionsVersioning)).ToList();
 
             using (var suppressTransaction = new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled))
             {

--- a/src/NServiceBus.RavenDB/Subscriptions/VersionedSubscriptionIdFormatter.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/VersionedSubscriptionIdFormatter.cs
@@ -1,0 +1,24 @@
+﻿namespace NServiceBus.RavenDB.Persistence.SubscriptionStorage
+{
+    using System;
+    using System.Security.Cryptography;
+    using System.Text;
+    using Unicast.Subscriptions;
+
+    class VersionedSubscriptionIdFormatter : ISubscriptionIdFormatter
+    {
+        public string FormatId(MessageType messageType)
+        {
+            // use MD5 hash to get a 16-byte hash of the string
+            using (var provider = new MD5CryptoServiceProvider())
+            {
+                var inputBytes = Encoding.Default.GetBytes(messageType.TypeName + "/" + messageType.Version.Major);
+                var hashBytes = provider.ComputeHash(inputBytes);
+                // generate a guid from the hash:
+                var id = new Guid(hashBytes);
+
+                return $"Subscriptions/{id}";
+            }
+        }
+    }
+}


### PR DESCRIPTION
Connects to #319 

Same result as #325 but with a better strategy and (IMO) more elegant result.
@DavidBoike simply take a look at the last commit https://github.com/Particular/NServiceBus.RavenDB/commit/cd6facbc4d3c92b62700ff92b532b6b69218961f