### PR TITLE
Warn users of RavenDB distributed transactions bug

### DIFF
--- a/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
@@ -76,6 +76,8 @@
             }
             else 
             {
+                Logger.Error("It's possible for RavenDB to lose data when used with Distributed Transaction Coordinator (DTC) transactions. Future versions of NServiceBus RavenDB Persistence will not support this combination. If using the same RavenDB database for NServiceBus data and all business data, you can change the TransportTransactionMode and enable the Outbox feature to maintain consistency between messaging operations and data persistence. See 'DTC not supported for RavenDB Persistence' in the documentation for more details.");  
+
                 if (store.JsonRequestFactory == null) // If the DocStore has not been initialized yet
                 {
                     if (store.ResourceManagerId == Guid.Empty || store.ResourceManagerId == ravenDefaultResourceManagerId)


### PR DESCRIPTION
Related to https://github.com/Particular/NServiceBus.RavenDB/issues/341

### Who's affected

All users of RavenDB persistence using DTC transactions are affected.

### Symptoms

RavenDB's implementation of distributed transactions contains a bug that could cause an NServiceBus endpoint, in certain (rare) conditions, to lose data. If RavenDB is configured to enlist in distributed transactions it's highly suggested to disable distributed transactions and enable the Outbox. For more information read [DTC not supported for RavenDB Persistence](https://docs.particular.net/persistence/ravendb/dtc).