### PR TITLE
Register UnwrappedSagaListener

### DIFF
--- a/src/NServiceBus.RavenDB.AcceptanceTests/HasUnwrappedSagaListenerRegistered.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/HasUnwrappedSagaListenerRegistered.cs
@@ -1,0 +1,99 @@
+﻿namespace NServiceBus.RavenDB.AcceptanceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using Raven.Client.Documents;
+    using Raven.Client.Documents.Session;
+
+    // TODO: Expand to create previous-version data like When_loading_Raven3_sagas unit test
+    public class HasUnwrappedSagaListenerRegistered : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task IsRegistered()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithSagaAndOutbox>(b => b.When((session, ctx) => session.SendLocal(new TestMsg())))
+                .Done(c => c.MessageReceived)
+                .Run();
+
+            Assert.IsTrue(context.IsRegistered, "Endpoint initialization is not registering UnwrappedSagaListener - sagas from before RavenDB 4.0 will not be able to be loaded.");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool IsRegistered { get; set; }
+            public bool MessageReceived { get; set; }
+        }
+
+        public class EndpointWithSagaAndOutbox : EndpointConfigurationBuilder
+        {
+            public EndpointWithSagaAndOutbox()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class BoringHandler : IHandleMessages<TestMsg>
+            {
+                Context testContext;
+
+                public BoringHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(TestMsg message, IMessageHandlerContext context)
+                {
+                    var session = context.SynchronizedStorageSession.RavenSession();
+                    var store = session.Advanced.DocumentStore as DocumentStore;
+
+                    testContext.IsRegistered = ListenerIsRegistered(store);
+                    testContext.MessageReceived = true;
+
+                    return Task.CompletedTask;
+                }
+            }
+
+            // It's a bit of a hack to do this by reflection, but there's just no other way (other than complicated smoke test) to ensure that this behavior is inserted
+            static bool ListenerIsRegistered(IDocumentStore store)
+            {
+                var eventInfo = typeof(DocumentStore).GetEvent("OnBeforeConversionToEntity");
+                var eventField = typeof(DocumentStoreBase).GetField("OnBeforeConversionToEntity", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.GetField);
+
+                var eventDelegate = eventField.GetValue(store) as EventHandler<BeforeConversionToEntityEventArgs>;
+
+                if (eventDelegate == null)
+                {
+                    return false;
+                }
+
+                foreach (var existingHandler in eventDelegate.GetInvocationList())
+                {
+                    if (existingHandler.Method.DeclaringType.Name == "UnwrappedSagaListener")
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            public class OrderSagaData : ContainSagaData
+            {
+                public string OrderId { get; set; }
+                public int ContinueCount { get; set; }
+                public List<int> CollectedIndexes { get; set; } = new List<int>();
+            }
+        }
+
+        public class TestMsg : ICommand
+        {
+            public string OrderId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB.AcceptanceTests/HasUnwrappedSagaListenerRegistered.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/HasUnwrappedSagaListenerRegistered.cs
@@ -62,7 +62,6 @@
             // It's a bit of a hack to do this by reflection, but there's just no other way (other than complicated smoke test) to ensure that this behavior is inserted
             static bool ListenerIsRegistered(IDocumentStore store)
             {
-                var eventInfo = typeof(DocumentStore).GetEvent("OnBeforeConversionToEntity");
                 var eventField = typeof(DocumentStoreBase).GetField("OnBeforeConversionToEntity", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.GetField);
 
                 var eventDelegate = eventField.GetValue(store) as EventHandler<BeforeConversionToEntityEventArgs>;

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_loading_Raven3_sagas.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_loading_Raven3_sagas.cs
@@ -13,7 +13,8 @@ using Raven.Client.Documents.Session;
 using Raven.Client.Json;
 
 [TestFixture]
-class When_loading_Raven3_sagas : RavenDBPersistenceTestBase
+// This class name is important - it's simple to make it easier to insert fake Raven3.x-like saga data
+class Raven3Sagas : RavenDBPersistenceTestBase
 {
     protected override void CustomizeDocumentStore(IDocumentStore docStore)
     {

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_loading_Raven3_sagas.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_loading_Raven3_sagas.cs
@@ -13,7 +13,7 @@ using Raven.Client.Documents.Session;
 using Raven.Client.Json;
 
 [TestFixture]
-class Raven3Sagas : RavenDBPersistenceTestBase
+class When_loading_Raven3_sagas : RavenDBPersistenceTestBase
 {
     protected override void CustomizeDocumentStore(IDocumentStore docStore)
     {

--- a/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
@@ -50,6 +50,8 @@
                 return;
             }
 
+            UnwrappedSagaListener.Register(store);
+
             var isSendOnly = settings.GetOrDefault<bool>("Endpoint.SendOnly");
             if (!isSendOnly)
             {


### PR DESCRIPTION
Whoops, forgot to register the unwrapped saga listener during endpoint initialization! Caught it during a smoke test. Added an acceptance test to ensure this doesn't regress.