### PR TITLE
Disable topology check

### DIFF
--- a/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
@@ -28,7 +28,7 @@
                 ApplyConventions(settings);
 
                 docStore.Initialize();
-                EnsureClusterConfiguration(docStore);
+                EnsureClusterConfiguration(docStore, settings);
             }
             isInitialized = true;
             return docStore;
@@ -63,8 +63,12 @@
             }
         }
 
-        void EnsureClusterConfiguration(IDocumentStore store)
+        void EnsureClusterConfiguration(IDocumentStore store, ReadOnlySettings settings)
         {
+            var skip = settings.GetOrDefault<bool>("RavenDB.DoNotEnsureClusterConfiguration");
+
+            if (skip) return;
+
             using (var s = store.OpenSession())
             {
                 var getTopologyCmd = new GetClusterTopologyCommand();

--- a/src/NServiceBus.RavenDB/Outbox/RavenDbOutboxStorage.cs
+++ b/src/NServiceBus.RavenDB/Outbox/RavenDbOutboxStorage.cs
@@ -60,7 +60,7 @@
 
             protected override async Task OnStop(IMessageSession session)
             {
-                cancellationTokenSource.Cancel();
+                cancellationTokenSource?.Cancel();
 
                 if (cleanupTask == null)
                 {

--- a/src/NServiceBus.RavenDB/RavenDbSettingsExtensions.cs
+++ b/src/NServiceBus.RavenDB/RavenDbSettingsExtensions.cs
@@ -96,5 +96,16 @@
             cfg.GetSettings().Set("RavenDB.DoNotSetupPermissions", true);
             return cfg;
         }
+        
+        /// <summary>
+        ///     Tells the persister to not check cluster topology to ensure consistency
+        /// </summary>
+        /// <param name="cfg"></param>
+        /// <returns></returns>
+        public static PersistenceExtensions<RavenDBPersistence> DoNotEnsureClusterConfiguration(this PersistenceExtensions<RavenDBPersistence> cfg)
+        {
+            cfg.GetSettings().Set("RavenDB.DoNotEnsureClusterConfiguration", true);
+            return cfg;
+        }
     }
 }


### PR DESCRIPTION
Allows users to bypass checking topology to allow users to run in a cluster environment.

Workaround for https://github.com/Particular/NServiceBus.RavenDB/issues/436.