### PR TITLE
Late resolve for IDocumentStore

### DIFF
--- a/src/NServiceBus.RavenDB.AcceptanceTests/When_providing_a_custom_document_store.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/When_providing_a_custom_document_store.cs
@@ -6,7 +6,6 @@
     using NServiceBus.AcceptanceTesting;
     using NUnit.Framework;
     using NServiceBus.AcceptanceTesting.Customization;
-    using NServiceBus.Logging;
     using NServiceBus.ObjectBuilder;
 
     [TestFixture]

--- a/src/NServiceBus.RavenDB.Tests/ApprovalFiles/APIApprovals.ApproveRavenDBPersistence.approved.txt
+++ b/src/NServiceBus.RavenDB.Tests/ApprovalFiles/APIApprovals.ApproveRavenDBPersistence.approved.txt
@@ -1,4 +1,4 @@
-﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute(@"NServiceBus.PersistersCompatibilityTests.NServiceBus5, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dde965e6172e019ac82c2639ffe494dd2e7dd16347c34762a05732b492e110f2e4e2e1b5ef2d85c848ccfb671ee20a47c8d1376276708dc30a90ff1121b647ba3b7259a6bc383b2034938ef0e275b58b920375ac605076178123693c6c4f1331661a62eba28c249386855637780e3ff5f23a6d854700eaa6803ef48907513b92")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute(@"NServiceBus.PersistersCompatibilityTests.NServiceBus5, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dde965e6172e019ac82c2639ffe494dd2e7dd16347c34762a05732b492e110f2e4e2e1b5ef2d85c848ccfb671ee20a47c8d1376276708dc30a90ff1121b647ba3b7259a6bc383b2034938ef0e275b58b920375ac605076178123693c6c4f1331661a62eba28c249386855637780e3ff5f23a6d854700eaa6803ef48907513b92")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute(@"NServiceBus.RavenDB.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dde965e6172e019ac82c2639ffe494dd2e7dd16347c34762a05732b492e110f2e4e2e1b5ef2d85c848ccfb671ee20a47c8d1376276708dc30a90ff1121b647ba3b7259a6bc383b2034938ef0e275b58b920375ac605076178123693c6c4f1331661a62eba28c249386855637780e3ff5f23a6d854700eaa6803ef48907513b92")]
 namespace NServiceBus.Persistence.RavenDB
 {
@@ -29,6 +29,7 @@ namespace NServiceBus
     {
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForGatewayDeduplication(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, Raven.Client.Documents.IDocumentStore documentStore) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForGatewayDeduplication(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.Settings.ReadOnlySettings, Raven.Client.Documents.IDocumentStore> storeCreator) { }
+        public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForGatewayDeduplication(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.ObjectBuilder.IBuilder, Raven.Client.Documents.IDocumentStore> storeCreator) { }
     }
     public class static RavenDBOutboxExtensions
     {
@@ -43,12 +44,14 @@ namespace NServiceBus
     {
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForSagas(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, Raven.Client.Documents.IDocumentStore documentStore) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForSagas(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.Settings.ReadOnlySettings, Raven.Client.Documents.IDocumentStore> storeCreator) { }
+        public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForSagas(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.ObjectBuilder.IBuilder, Raven.Client.Documents.IDocumentStore> storeCreator) { }
     }
     public class static RavenDbSettingsExtensions
     {
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> DoNotSetupDatabasePermissions(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> SetDefaultDocumentStore(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, Raven.Client.Documents.IDocumentStore documentStore) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> SetDefaultDocumentStore(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.Settings.ReadOnlySettings, Raven.Client.Documents.IDocumentStore> storeCreator) { }
+        public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> SetDefaultDocumentStore(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.ObjectBuilder.IBuilder, Raven.Client.Documents.IDocumentStore> storeCreator) { }
         [System.ObsoleteAttribute("ConnectionParameters is no longer supported. Use an alternate overload and supply" +
             " the fully configured IDocumentStore. The member currently throws a NotImplement" +
             "edException. Will be removed in version 7.0.0.", true)]
@@ -65,6 +68,7 @@ namespace NServiceBus
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> DoNotCacheSubscriptions(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForSubscriptions(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, Raven.Client.Documents.IDocumentStore documentStore) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForSubscriptions(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.Settings.ReadOnlySettings, Raven.Client.Documents.IDocumentStore> storeCreator) { }
+        public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForSubscriptions(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.ObjectBuilder.IBuilder, Raven.Client.Documents.IDocumentStore> storeCreator) { }
         [System.ObsoleteAttribute("Subscriptions must be converted to the new format. Will be removed in version 7.0" +
             ".0.", true)]
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseLegacyVersionedSubscriptions(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg) { }
@@ -73,6 +77,7 @@ namespace NServiceBus
     {
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForTimeouts(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, Raven.Client.Documents.IDocumentStore documentStore) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForTimeouts(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.Settings.ReadOnlySettings, Raven.Client.Documents.IDocumentStore> storeCreator) { }
+        public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForTimeouts(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.ObjectBuilder.IBuilder, Raven.Client.Documents.IDocumentStore> storeCreator) { }
     }
     public class static RavenSessionExtension
     {

--- a/src/NServiceBus.RavenDB.Tests/Persistence/DocumentStoreManagerTests.cs
+++ b/src/NServiceBus.RavenDB.Tests/Persistence/DocumentStoreManagerTests.cs
@@ -29,11 +29,11 @@
 
                 var readOnly = settings as ReadOnlySettings;
 
-                Assert.AreEqual("GatewayDeduplication", DocumentStoreManager.GetDocumentStore<StorageType.GatewayDeduplication>(readOnly).Identifier);
-                Assert.AreEqual("Outbox", DocumentStoreManager.GetDocumentStore<StorageType.Outbox>(readOnly).Identifier);
-                Assert.AreEqual("Sagas", DocumentStoreManager.GetDocumentStore<StorageType.Sagas>(readOnly).Identifier);
-                Assert.AreEqual("Subscriptions", DocumentStoreManager.GetDocumentStore<StorageType.Subscriptions>(readOnly).Identifier);
-                Assert.AreEqual("Timeouts", DocumentStoreManager.GetDocumentStore<StorageType.Timeouts>(readOnly).Identifier);
+                Assert.AreEqual("GatewayDeduplication", DocumentStoreManager.GetDocumentStore<StorageType.GatewayDeduplication>(readOnly, null).Identifier);
+                Assert.AreEqual("Outbox", DocumentStoreManager.GetDocumentStore<StorageType.Outbox>(readOnly, null).Identifier);
+                Assert.AreEqual("Sagas", DocumentStoreManager.GetDocumentStore<StorageType.Sagas>(readOnly, null).Identifier);
+                Assert.AreEqual("Subscriptions", DocumentStoreManager.GetDocumentStore<StorageType.Subscriptions>(readOnly, null).Identifier);
+                Assert.AreEqual("Timeouts", DocumentStoreManager.GetDocumentStore<StorageType.Timeouts>(readOnly, null).Identifier);
             }
         }
     }

--- a/src/NServiceBus.RavenDB.Tests/When_providing_a_custom_document_store.cs
+++ b/src/NServiceBus.RavenDB.Tests/When_providing_a_custom_document_store.cs
@@ -1,11 +1,8 @@
-﻿namespace NServiceBus.RavenDB.AcceptanceTests
+﻿namespace NServiceBus.RavenDB.Tests
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
-    using NServiceBus.AcceptanceTesting;
     using NUnit.Framework;
-    using NServiceBus.AcceptanceTesting.Customization;
     using NServiceBus.ObjectBuilder;
 
     [TestFixture]
@@ -14,18 +11,10 @@
         [Test]
         public void Should_not_resolve_until_start()
         {
-            // workaround to avoid NRE in the logging due to static caching of the loggers.
-            Scenario.Define<ScenarioContext>().Done(_ => true).Run();
-
             var endpointConfiguration = new EndpointConfiguration("custom-docstore-endpoint");
 
-            var typesToInclude = new List<Type> { typeof(MySaga) };
-
-            //need to include the NServiceBus.RavenDB types since the features need to be discovered
-            typesToInclude.AddRange(typeof(RavenDBPersistence).Assembly.GetTypes());
-
-            endpointConfiguration.TypesToIncludeInScan(typesToInclude);
-            endpointConfiguration.UseTransport<AcceptanceTestingTransport>();
+            endpointConfiguration.AssemblyScanner().ExcludeAssemblies("NServiceBus.RavenDB.Tests");
+            endpointConfiguration.UseTransport<LearningTransport>();
             endpointConfiguration.EnableOutbox();
 
             endpointConfiguration.UsePersistence<RavenDBPersistence>()

--- a/src/NServiceBus.RavenDB/Gateway/RavenDbGatewayDeduplication.cs
+++ b/src/NServiceBus.RavenDB/Gateway/RavenDbGatewayDeduplication.cs
@@ -11,9 +11,11 @@
 
         protected override void Setup(FeatureConfigurationContext context)
         {
-            var store = DocumentStoreManager.GetDocumentStore<StorageType.GatewayDeduplication>(context.Settings);
-
-            context.Container.ConfigureComponent(b=>new RavenDeduplication(store), DependencyLifecycle.SingleInstance);
+            context.Container.ConfigureComponent(builder =>
+            {
+                var store = DocumentStoreManager.GetDocumentStore<StorageType.GatewayDeduplication>(context.Settings, builder);
+                return new RavenDeduplication(store);
+            }, DependencyLifecycle.SingleInstance);
         }
     }
 }

--- a/src/NServiceBus.RavenDB/Gateway/RavenDbGatewayDeduplicationSettingsExtensions.cs
+++ b/src/NServiceBus.RavenDB/Gateway/RavenDbGatewayDeduplicationSettingsExtensions.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using NServiceBus.Configuration.AdvancedExtensibility;
+    using NServiceBus.ObjectBuilder;
     using NServiceBus.Persistence.RavenDB;
     using NServiceBus.Settings;
     using Raven.Client.Documents;
@@ -28,6 +29,17 @@
         /// <param name="cfg"></param>
         /// <param name="storeCreator">A Func that will create the document store on NServiceBus initialization.</param>
         public static PersistenceExtensions<RavenDBPersistence> UseDocumentStoreForGatewayDeduplication(this PersistenceExtensions<RavenDBPersistence> cfg, Func<ReadOnlySettings, IDocumentStore> storeCreator)
+        {
+            DocumentStoreManager.SetDocumentStore<StorageType.GatewayDeduplication>(cfg.GetSettings(), storeCreator);
+            return cfg;
+        }
+
+        /// <summary>
+        ///     Configures the given document store to be used when storing gateway deduplication data
+        /// </summary>
+        /// <param name="cfg"></param>
+        /// <param name="storeCreator">A Func that will create the document store on NServiceBus initialization.</param>
+        public static PersistenceExtensions<RavenDBPersistence> UseDocumentStoreForGatewayDeduplication(this PersistenceExtensions<RavenDBPersistence> cfg, Func<IBuilder, IDocumentStore> storeCreator)
         {
             DocumentStoreManager.SetDocumentStore<StorageType.GatewayDeduplication>(cfg.GetSettings(), storeCreator);
             return cfg;

--- a/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
@@ -29,7 +29,7 @@
         /// and undocumented possibilities of failure.
         /// Will throw iff index registration failed and index doesn't exist or it exists but with a non-current definition.
         /// </summary>
-        internal void SafelyCreateIndex(AbstractIndexCreationTask index)
+        internal void CreateIndexOnInitialization(AbstractIndexCreationTask index)
         {
             indexesToCreate.Add(index);
         }

--- a/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
@@ -2,29 +2,30 @@
 {
     using System;
     using NServiceBus.ConsistencyGuarantees;
+    using NServiceBus.ObjectBuilder;
     using NServiceBus.Settings;
     using Raven.Client.Documents;
     using Raven.Client.ServerWide.Commands;
 
     class DocumentStoreInitializer
     {
-        internal DocumentStoreInitializer(Func<ReadOnlySettings, IDocumentStore> storeCreator)
+        internal DocumentStoreInitializer(Func<ReadOnlySettings, IBuilder, IDocumentStore> storeCreator)
         {
             this.storeCreator = storeCreator;
         }
 
         internal DocumentStoreInitializer(IDocumentStore store)
         {
-            storeCreator = readOnlySettings => store;
+            storeCreator = (s,c) => store;
         }
 
         public string Identifier => docStore?.Identifier;
 
-        internal IDocumentStore Init(ReadOnlySettings settings)
+        internal IDocumentStore Init(ReadOnlySettings settings, IBuilder builder)
         {
             if (!isInitialized)
             {
-                EnsureDocStoreCreated(settings);
+                EnsureDocStoreCreated(settings, builder);
                 ApplyConventions(settings);
 
                 docStore.Initialize();
@@ -34,11 +35,11 @@
             return docStore;
         }
 
-        void EnsureDocStoreCreated(ReadOnlySettings settings)
+        void EnsureDocStoreCreated(ReadOnlySettings settings, IBuilder builder)
         {
             if (docStore == null)
             {
-                docStore = storeCreator(settings);
+                docStore = storeCreator(settings, builder);
             }
         }
 
@@ -80,7 +81,7 @@
             }
         }
 
-        Func<ReadOnlySettings, IDocumentStore> storeCreator;
+        Func<ReadOnlySettings, IBuilder, IDocumentStore> storeCreator;
         IDocumentStore docStore;
         bool isInitialized;
     }

--- a/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
@@ -1,10 +1,13 @@
 ﻿namespace NServiceBus.Persistence.RavenDB
 {
     using System;
+    using System.Collections.Generic;
     using NServiceBus.ConsistencyGuarantees;
     using NServiceBus.ObjectBuilder;
     using NServiceBus.Settings;
     using Raven.Client.Documents;
+    using Raven.Client.Documents.Indexes;
+    using Raven.Client.Documents.Operations.Indexes;
     using Raven.Client.ServerWide.Commands;
 
     class DocumentStoreInitializer
@@ -16,10 +19,39 @@
 
         internal DocumentStoreInitializer(IDocumentStore store)
         {
-            storeCreator = (s,c) => store;
+            storeCreator = (s, c) => store;
         }
 
         public string Identifier => docStore?.Identifier;
+
+        /// <summary>
+        /// Safely add the index to the RavenDB database, protect against possible failures caused by documented
+        /// and undocumented possibilities of failure.
+        /// Will throw iff index registration failed and index doesn't exist or it exists but with a non-current definition.
+        /// </summary>
+        internal void SafelyCreateIndex(AbstractIndexCreationTask index)
+        {
+            indexesToCreate.Add(index);
+        }
+
+        void CreateIndexes(IDocumentStore store)
+        {
+            foreach (var index in indexesToCreate)
+            {
+                try
+                {
+                    index.Execute(store);
+                }
+                catch (Exception) // Apparently ArgumentException can be thrown as well as a WebException; not taking any chances
+                {
+                    var getIndexOp = new GetIndexOperation(index.IndexName);
+
+                    var existingIndex = store.Maintenance.Send(getIndexOp);
+                    if (existingIndex == null || !index.CreateIndexDefinition().Equals(existingIndex))
+                        throw;
+                }
+            }
+        }
 
         internal IDocumentStore Init(ReadOnlySettings settings, IBuilder builder)
         {
@@ -30,7 +62,10 @@
 
                 docStore.Initialize();
                 EnsureClusterConfiguration(docStore);
+
+                CreateIndexes(docStore);
             }
+
             isInitialized = true;
             return docStore;
         }
@@ -81,6 +116,7 @@
             }
         }
 
+        List<AbstractIndexCreationTask> indexesToCreate = new List<AbstractIndexCreationTask>();
         Func<ReadOnlySettings, IBuilder, IDocumentStore> storeCreator;
         IDocumentStore docStore;
         bool isInitialized;

--- a/src/NServiceBus.RavenDB/Internal/Helpers.cs
+++ b/src/NServiceBus.RavenDB/Internal/Helpers.cs
@@ -3,8 +3,6 @@
     using System;
     using NServiceBus.Logging;
     using Raven.Client.Documents;
-    using Raven.Client.Documents.Indexes;
-    using Raven.Client.Documents.Operations.Indexes;
 
     class Helpers
     {
@@ -32,29 +30,6 @@ Original exception: {exception}";
             {
                 LogRavenConnectionFailure(e, documentStore);
                 throw;
-            }
-        }
-
-        /// <summary>
-        /// Safely add the index to the RavenDB database, protect against possible failures caused by documented
-        /// and undocumented possibilities of failure.
-        /// Will throw iff index registration failed and index doesn't exist or it exists but with a non-current definition.
-        /// </summary>
-        /// <param name="store"></param>
-        /// <param name="index"></param>
-        internal static void SafelyCreateIndex(IDocumentStore store, AbstractIndexCreationTask index)
-        {
-            try
-            {
-                index.Execute(store);
-            }
-            catch (Exception) // Apparently ArgumentException can be thrown as well as a WebException; not taking any chances
-            {
-                var getIndexOp = new GetIndexOperation(index.IndexName);
-
-                var existingIndex = store.Maintenance.Send(getIndexOp);
-                if (existingIndex == null || !index.CreateIndexDefinition().Equals(existingIndex))
-                    throw;
             }
         }
     }

--- a/src/NServiceBus.RavenDB/Outbox/RavenDbOutboxStorage.cs
+++ b/src/NServiceBus.RavenDB/Outbox/RavenDbOutboxStorage.cs
@@ -19,7 +19,7 @@
             var endpointName = context.Settings.EndpointName();
 
             DocumentStoreManager.GetUninitializedDocumentStore<StorageType.Outbox>(context.Settings)
-                .SafelyCreateIndex(new OutboxRecordsIndex());
+                .CreateIndexOnInitialization(new OutboxRecordsIndex());
 
             context.Container.ConfigureComponent(b =>
             {

--- a/src/NServiceBus.RavenDB/Outbox/RavenDbOutboxStorage.cs
+++ b/src/NServiceBus.RavenDB/Outbox/RavenDbOutboxStorage.cs
@@ -33,7 +33,7 @@
                 return new OutboxRecordsCleaner(store);
             }, DependencyLifecycle.InstancePerCall);
 
-            context.Container.ConfigureComponent(b => new OutboxCleaner(b.Build<OutboxRecordsCleaner>(), context.Settings), DependencyLifecycle.InstancePerCall);
+            context.Container.ConfigureComponent<OutboxCleaner>(DependencyLifecycle.InstancePerCall);
 
             context.RegisterStartupTask(builder => builder.Build<OutboxCleaner>());
         }

--- a/src/NServiceBus.RavenDB/RavenDbSettingsExtensions.cs
+++ b/src/NServiceBus.RavenDB/RavenDbSettingsExtensions.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using NServiceBus.Configuration.AdvancedExtensibility;
+    using NServiceBus.ObjectBuilder;
     using NServiceBus.Persistence.RavenDB;
     using NServiceBus.Settings;
     using Raven.Client.Documents;
@@ -34,6 +35,18 @@
         /// <param name="storeCreator">A Func that will create the document store on NServiceBus initialization.</param>
         /// <returns></returns>
         public static PersistenceExtensions<RavenDBPersistence> SetDefaultDocumentStore(this PersistenceExtensions<RavenDBPersistence> cfg, Func<ReadOnlySettings, IDocumentStore> storeCreator)
+        {
+            DocumentStoreManager.SetDefaultStore(cfg.GetSettings(), storeCreator);
+            return cfg;
+        }
+
+        /// <summary>
+        ///     Configures the storages to use the given document store supplied
+        /// </summary>
+        /// <param name="cfg"></param>
+        /// <param name="storeCreator">A Func that will create the document store on NServiceBus initialization.</param>
+        /// <returns></returns>
+        public static PersistenceExtensions<RavenDBPersistence> SetDefaultDocumentStore(this PersistenceExtensions<RavenDBPersistence> cfg, Func<IBuilder, IDocumentStore> storeCreator)
         {
             DocumentStoreManager.SetDefaultStore(cfg.GetSettings(), storeCreator);
             return cfg;

--- a/src/NServiceBus.RavenDB/SagaPersister/RavenDbSagaSettingsExtensions.cs
+++ b/src/NServiceBus.RavenDB/SagaPersister/RavenDbSagaSettingsExtensions.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using NServiceBus.Configuration.AdvancedExtensibility;
+    using NServiceBus.ObjectBuilder;
     using NServiceBus.Persistence.RavenDB;
     using NServiceBus.Settings;
     using Raven.Client.Documents;
@@ -34,6 +35,16 @@
             DocumentStoreManager.SetDocumentStore<StorageType.Sagas>(cfg.GetSettings(), storeCreator);
             return cfg;
         }
-        
+
+        /// <summary>
+        ///     Configures the given document store to be used when storing sagas
+        /// </summary>
+        /// <param name="cfg">Object to attach to</param>
+        /// <param name="storeCreator">A Func that will create the document store on NServiceBus initialization.</param>
+        public static PersistenceExtensions<RavenDBPersistence> UseDocumentStoreForSagas(this PersistenceExtensions<RavenDBPersistence> cfg, Func<IBuilder, IDocumentStore> storeCreator)
+        {
+            DocumentStoreManager.SetDocumentStore<StorageType.Sagas>(cfg.GetSettings(), storeCreator);
+            return cfg;
+        }
     }
 }

--- a/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionSettingsExtensions.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionSettingsExtensions.cs
@@ -15,7 +15,6 @@
         internal const string DoNotAggressivelyCacheSubscriptionsSettingsKey = "RavenDB.DoNotAggressivelyCacheSubscriptions";
         internal const string AggressiveCacheDurationSettingsKey = "RavenDB.AggressiveCacheDuration";
 
-        //TODO fix these too
         /// <summary>
         ///     Configures the given document store to be used when storing subscriptions
         /// </summary>

--- a/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionSettingsExtensions.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionSettingsExtensions.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using NServiceBus.Configuration.AdvancedExtensibility;
+    using NServiceBus.ObjectBuilder;
     using NServiceBus.Persistence.RavenDB;
     using NServiceBus.Settings;
     using Raven.Client.Documents;
@@ -14,6 +15,7 @@
         internal const string DoNotAggressivelyCacheSubscriptionsSettingsKey = "RavenDB.DoNotAggressivelyCacheSubscriptions";
         internal const string AggressiveCacheDurationSettingsKey = "RavenDB.AggressiveCacheDuration";
 
+        //TODO fix these too
         /// <summary>
         ///     Configures the given document store to be used when storing subscriptions
         /// </summary>
@@ -37,11 +39,21 @@
         }
 
         /// <summary>
+        ///     Configures the given document store to be used when storing subscriptions
+        /// </summary>
+        /// <param name="cfg"></param>
+        /// <param name="storeCreator">A Func that will create the document store on NServiceBus initialization.</param>
+        public static PersistenceExtensions<RavenDBPersistence> UseDocumentStoreForSubscriptions(this PersistenceExtensions<RavenDBPersistence> cfg, Func<IBuilder, IDocumentStore> storeCreator)
+        {
+            DocumentStoreManager.SetDocumentStore<StorageType.Subscriptions>(cfg.GetSettings(), storeCreator);
+            return cfg;
+        }
+
+        /// <summary>
         /// Disable in-memory caching of Subscription information. By default, NServiceBus will cache subscriptions in memory
         /// until a server notification informs the RavenDB client of a change, or 1 minute elapses, whichever occurs first.
         /// Although slower, using this option ensures that the subscription storage is checked for changes with every published message.
         /// </summary>
-        /// <param name="cfg"></param>
         public static PersistenceExtensions<RavenDBPersistence> DoNotCacheSubscriptions(this PersistenceExtensions<RavenDBPersistence> cfg)
         {
             cfg.GetSettings().Set(DoNotAggressivelyCacheSubscriptionsSettingsKey, true);

--- a/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionStorage.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionStorage.cs
@@ -13,21 +13,24 @@
 
         protected override void Setup(FeatureConfigurationContext context)
         {
-            var store = DocumentStoreManager.GetDocumentStore<StorageType.Subscriptions>(context.Settings);
-
-            var persister = new SubscriptionPersister(store);
-
-            if (context.Settings.GetOrDefault<bool>(RavenDbSubscriptionSettingsExtensions.DoNotAggressivelyCacheSubscriptionsSettingsKey))
+            context.Container.ConfigureComponent<ISubscriptionStorage>(b =>
             {
-                persister.DisableAggressiveCaching = true;
-            }
+                var store = DocumentStoreManager.GetDocumentStore<StorageType.Subscriptions>(context.Settings, b);
 
-            if (context.Settings.TryGet(RavenDbSubscriptionSettingsExtensions.AggressiveCacheDurationSettingsKey, out TimeSpan aggressiveCacheDuration))
-            {
-                persister.AggressiveCacheDuration = aggressiveCacheDuration;
-            }
+                var persister = new SubscriptionPersister(store);
 
-            context.Container.ConfigureComponent<ISubscriptionStorage>(_ => persister, DependencyLifecycle.SingleInstance);
+                if (context.Settings.GetOrDefault<bool>(RavenDbSubscriptionSettingsExtensions.DoNotAggressivelyCacheSubscriptionsSettingsKey))
+                {
+                    persister.DisableAggressiveCaching = true;
+                }
+
+                if (context.Settings.TryGet(RavenDbSubscriptionSettingsExtensions.AggressiveCacheDurationSettingsKey, out TimeSpan aggressiveCacheDuration))
+                {
+                    persister.AggressiveCacheDuration = aggressiveCacheDuration;
+                }
+
+                return persister;
+            }, DependencyLifecycle.SingleInstance);
         }
 
         static readonly ILog Log = LogManager.GetLogger<RavenDbSubscriptionStorage>();

--- a/src/NServiceBus.RavenDB/Timeouts/RavenDbTimeoutSettingsExtensions.cs
+++ b/src/NServiceBus.RavenDB/Timeouts/RavenDbTimeoutSettingsExtensions.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using NServiceBus.Configuration.AdvancedExtensibility;
+    using NServiceBus.ObjectBuilder;
     using NServiceBus.Persistence.RavenDB;
     using NServiceBus.Settings;
     using Raven.Client.Documents;
@@ -28,6 +29,17 @@
         /// <param name="cfg"></param>
         /// <param name="storeCreator">A Func that will create the document store on NServiceBus initialization.</param>
         public static PersistenceExtensions<RavenDBPersistence> UseDocumentStoreForTimeouts(this PersistenceExtensions<RavenDBPersistence> cfg, Func<ReadOnlySettings, IDocumentStore> storeCreator)
+        {
+            DocumentStoreManager.SetDocumentStore<StorageType.Timeouts>(cfg.GetSettings(), storeCreator);
+            return cfg;
+        }
+
+        /// <summary>
+        ///     Configures the given document store to be used when storing timeouts
+        /// </summary>
+        /// <param name="cfg"></param>
+        /// <param name="storeCreator">A Func that will create the document store on NServiceBus initialization.</param>
+        public static PersistenceExtensions<RavenDBPersistence> UseDocumentStoreForTimeouts(this PersistenceExtensions<RavenDBPersistence> cfg, Func<IBuilder, IDocumentStore> storeCreator)
         {
             DocumentStoreManager.SetDocumentStore<StorageType.Timeouts>(cfg.GetSettings(), storeCreator);
             return cfg;

--- a/src/NServiceBus.RavenDB/Timeouts/RavenDbTimeoutStorage.cs
+++ b/src/NServiceBus.RavenDB/Timeouts/RavenDbTimeoutStorage.cs
@@ -14,7 +14,7 @@
         {
             //var store = DocumentStoreManager.GetDocumentStore<StorageType.Timeouts>(context.Settings);
             DocumentStoreManager.GetUninitializedDocumentStore<StorageType.Timeouts>(context.Settings)
-                .SafelyCreateIndex(new TimeoutsIndex());
+                .CreateIndexOnInitialization(new TimeoutsIndex());
 
             context.Container.ConfigureComponent(b =>
             {


### PR DESCRIPTION
fixes #445 
fixes #444 

Very rough first hack to change the RavenDB setup so that the IDocumentStore can be resolved from a configurable factory method which has access to the `IBuilder` so that it can be resolved from DI.

This requires to resolve the document store in many places at a later point, so the it's being resolved when the dependent service is built. At this point the endpoint has already started and the DI container is ready to resolve services.

For the sake of simplicity in this spike I've moved the index creation to the feature's related startup task, this should hopefully ensure that indexes are created before anyone relying on them is running. Using a dedicated FST for index creation could be tricky as we could run into ordering issues. It might be easier to add an API to the `DocumentStoreInitializer` to allow registering custom callbacks to setup indexes when the document store is resolved.