### PR TITLE
Change extension methods to avoid ambiguous method invocations

### DIFF
--- a/src/NServiceBus.RavenDB.Tests/ApprovalFiles/APIApprovals.ApproveRavenDBPersistence.approved.txt
+++ b/src/NServiceBus.RavenDB.Tests/ApprovalFiles/APIApprovals.ApproveRavenDBPersistence.approved.txt
@@ -29,7 +29,7 @@ namespace NServiceBus
     {
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForGatewayDeduplication(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, Raven.Client.Documents.IDocumentStore documentStore) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForGatewayDeduplication(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.Settings.ReadOnlySettings, Raven.Client.Documents.IDocumentStore> storeCreator) { }
-        public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForGatewayDeduplication(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.ObjectBuilder.IBuilder, Raven.Client.Documents.IDocumentStore> storeCreator) { }
+        public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForGatewayDeduplication(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.Settings.ReadOnlySettings, NServiceBus.ObjectBuilder.IBuilder, Raven.Client.Documents.IDocumentStore> storeCreator) { }
     }
     public class static RavenDBOutboxExtensions
     {
@@ -44,14 +44,14 @@ namespace NServiceBus
     {
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForSagas(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, Raven.Client.Documents.IDocumentStore documentStore) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForSagas(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.Settings.ReadOnlySettings, Raven.Client.Documents.IDocumentStore> storeCreator) { }
-        public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForSagas(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.ObjectBuilder.IBuilder, Raven.Client.Documents.IDocumentStore> storeCreator) { }
+        public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForSagas(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.Settings.ReadOnlySettings, NServiceBus.ObjectBuilder.IBuilder, Raven.Client.Documents.IDocumentStore> storeCreator) { }
     }
     public class static RavenDbSettingsExtensions
     {
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> DoNotSetupDatabasePermissions(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> SetDefaultDocumentStore(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, Raven.Client.Documents.IDocumentStore documentStore) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> SetDefaultDocumentStore(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.Settings.ReadOnlySettings, Raven.Client.Documents.IDocumentStore> storeCreator) { }
-        public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> SetDefaultDocumentStore(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.ObjectBuilder.IBuilder, Raven.Client.Documents.IDocumentStore> storeCreator) { }
+        public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> SetDefaultDocumentStore(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.Settings.ReadOnlySettings, NServiceBus.ObjectBuilder.IBuilder, Raven.Client.Documents.IDocumentStore> storeCreator) { }
         [System.ObsoleteAttribute("ConnectionParameters is no longer supported. Use an alternate overload and supply" +
             " the fully configured IDocumentStore. The member currently throws a NotImplement" +
             "edException. Will be removed in version 7.0.0.", true)]
@@ -68,7 +68,7 @@ namespace NServiceBus
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> DoNotCacheSubscriptions(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForSubscriptions(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, Raven.Client.Documents.IDocumentStore documentStore) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForSubscriptions(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.Settings.ReadOnlySettings, Raven.Client.Documents.IDocumentStore> storeCreator) { }
-        public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForSubscriptions(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.ObjectBuilder.IBuilder, Raven.Client.Documents.IDocumentStore> storeCreator) { }
+        public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForSubscriptions(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.Settings.ReadOnlySettings, NServiceBus.ObjectBuilder.IBuilder, Raven.Client.Documents.IDocumentStore> storeCreator) { }
         [System.ObsoleteAttribute("Subscriptions must be converted to the new format. Will be removed in version 7.0" +
             ".0.", true)]
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseLegacyVersionedSubscriptions(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg) { }
@@ -77,7 +77,7 @@ namespace NServiceBus
     {
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForTimeouts(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, Raven.Client.Documents.IDocumentStore documentStore) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForTimeouts(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.Settings.ReadOnlySettings, Raven.Client.Documents.IDocumentStore> storeCreator) { }
-        public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForTimeouts(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.ObjectBuilder.IBuilder, Raven.Client.Documents.IDocumentStore> storeCreator) { }
+        public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseDocumentStoreForTimeouts(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.Settings.ReadOnlySettings, NServiceBus.ObjectBuilder.IBuilder, Raven.Client.Documents.IDocumentStore> storeCreator) { }
     }
     public class static RavenSessionExtension
     {

--- a/src/NServiceBus.RavenDB.Tests/When_providing_a_custom_document_store.cs
+++ b/src/NServiceBus.RavenDB.Tests/When_providing_a_custom_document_store.cs
@@ -18,7 +18,7 @@
             endpointConfiguration.EnableOutbox();
 
             endpointConfiguration.UsePersistence<RavenDBPersistence>()
-                    .SetDefaultDocumentStore((IBuilder builder) =>
+                    .SetDefaultDocumentStore((_, __) =>
                     {
                         Assert.Fail("Document store resolved to early");
 

--- a/src/NServiceBus.RavenDB/Gateway/RavenDbGatewayDeduplicationSettingsExtensions.cs
+++ b/src/NServiceBus.RavenDB/Gateway/RavenDbGatewayDeduplicationSettingsExtensions.cs
@@ -39,7 +39,7 @@
         /// </summary>
         /// <param name="cfg"></param>
         /// <param name="storeCreator">A Func that will create the document store on NServiceBus initialization.</param>
-        public static PersistenceExtensions<RavenDBPersistence> UseDocumentStoreForGatewayDeduplication(this PersistenceExtensions<RavenDBPersistence> cfg, Func<IBuilder, IDocumentStore> storeCreator)
+        public static PersistenceExtensions<RavenDBPersistence> UseDocumentStoreForGatewayDeduplication(this PersistenceExtensions<RavenDBPersistence> cfg, Func<ReadOnlySettings, IBuilder, IDocumentStore> storeCreator)
         {
             DocumentStoreManager.SetDocumentStore<StorageType.GatewayDeduplication>(cfg.GetSettings(), storeCreator);
             return cfg;

--- a/src/NServiceBus.RavenDB/Internal/DocumentStoreManager.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentStoreManager.cs
@@ -42,14 +42,14 @@
             SetDocumentStoreInternal(settings, typeof(TStorageType), (s, _) => storeCreator(s));
         }
 
-        public static void SetDocumentStore<TStorageType>(SettingsHolder settings, Func<IBuilder, IDocumentStore> storeCreator)
+        public static void SetDocumentStore<TStorageType>(SettingsHolder settings, Func<ReadOnlySettings, IBuilder, IDocumentStore> storeCreator)
             where TStorageType : StorageType
         {
             if (storeCreator == null)
             {
                 throw new ArgumentNullException(nameof(storeCreator));
             }
-            SetDocumentStoreInternal(settings, typeof(TStorageType), (_, b) => storeCreator(b));
+            SetDocumentStoreInternal(settings, typeof(TStorageType), storeCreator);
         }
 
         static void SetDocumentStoreInternal(SettingsHolder settings, Type storageType, Func<ReadOnlySettings, IBuilder, IDocumentStore> storeCreator)
@@ -76,13 +76,13 @@
             SetDefaultStoreInternal(settings, (s, _) => storeCreator(s));
         }
 
-        public static void SetDefaultStore(SettingsHolder settings, Func<IBuilder, IDocumentStore> storeCreator)
+        public static void SetDefaultStore(SettingsHolder settings, Func<ReadOnlySettings, IBuilder, IDocumentStore> storeCreator)
         {
             if (storeCreator == null)
             {
                 throw new ArgumentNullException(nameof(storeCreator));
             }
-            SetDefaultStoreInternal(settings, (_, b) => storeCreator(b));
+            SetDefaultStoreInternal(settings, storeCreator);
         }
 
         static void SetDefaultStoreInternal(SettingsHolder settings, Func<ReadOnlySettings, IBuilder, IDocumentStore> storeCreator)

--- a/src/NServiceBus.RavenDB/RavenDbSettingsExtensions.cs
+++ b/src/NServiceBus.RavenDB/RavenDbSettingsExtensions.cs
@@ -46,7 +46,7 @@
         /// <param name="cfg"></param>
         /// <param name="storeCreator">A Func that will create the document store on NServiceBus initialization.</param>
         /// <returns></returns>
-        public static PersistenceExtensions<RavenDBPersistence> SetDefaultDocumentStore(this PersistenceExtensions<RavenDBPersistence> cfg, Func<IBuilder, IDocumentStore> storeCreator)
+        public static PersistenceExtensions<RavenDBPersistence> SetDefaultDocumentStore(this PersistenceExtensions<RavenDBPersistence> cfg, Func<ReadOnlySettings, IBuilder, IDocumentStore> storeCreator)
         {
             DocumentStoreManager.SetDefaultStore(cfg.GetSettings(), storeCreator);
             return cfg;

--- a/src/NServiceBus.RavenDB/SagaPersister/RavenDbSagaSettingsExtensions.cs
+++ b/src/NServiceBus.RavenDB/SagaPersister/RavenDbSagaSettingsExtensions.cs
@@ -41,7 +41,7 @@
         /// </summary>
         /// <param name="cfg">Object to attach to</param>
         /// <param name="storeCreator">A Func that will create the document store on NServiceBus initialization.</param>
-        public static PersistenceExtensions<RavenDBPersistence> UseDocumentStoreForSagas(this PersistenceExtensions<RavenDBPersistence> cfg, Func<IBuilder, IDocumentStore> storeCreator)
+        public static PersistenceExtensions<RavenDBPersistence> UseDocumentStoreForSagas(this PersistenceExtensions<RavenDBPersistence> cfg, Func<ReadOnlySettings, IBuilder, IDocumentStore> storeCreator)
         {
             DocumentStoreManager.SetDocumentStore<StorageType.Sagas>(cfg.GetSettings(), storeCreator);
             return cfg;

--- a/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionSettingsExtensions.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionSettingsExtensions.cs
@@ -42,7 +42,7 @@
         /// </summary>
         /// <param name="cfg"></param>
         /// <param name="storeCreator">A Func that will create the document store on NServiceBus initialization.</param>
-        public static PersistenceExtensions<RavenDBPersistence> UseDocumentStoreForSubscriptions(this PersistenceExtensions<RavenDBPersistence> cfg, Func<IBuilder, IDocumentStore> storeCreator)
+        public static PersistenceExtensions<RavenDBPersistence> UseDocumentStoreForSubscriptions(this PersistenceExtensions<RavenDBPersistence> cfg, Func<ReadOnlySettings, IBuilder, IDocumentStore> storeCreator)
         {
             DocumentStoreManager.SetDocumentStore<StorageType.Subscriptions>(cfg.GetSettings(), storeCreator);
             return cfg;

--- a/src/NServiceBus.RavenDB/Timeouts/RavenDbTimeoutSettingsExtensions.cs
+++ b/src/NServiceBus.RavenDB/Timeouts/RavenDbTimeoutSettingsExtensions.cs
@@ -39,7 +39,7 @@
         /// </summary>
         /// <param name="cfg"></param>
         /// <param name="storeCreator">A Func that will create the document store on NServiceBus initialization.</param>
-        public static PersistenceExtensions<RavenDBPersistence> UseDocumentStoreForTimeouts(this PersistenceExtensions<RavenDBPersistence> cfg, Func<IBuilder, IDocumentStore> storeCreator)
+        public static PersistenceExtensions<RavenDBPersistence> UseDocumentStoreForTimeouts(this PersistenceExtensions<RavenDBPersistence> cfg, Func<ReadOnlySettings, IBuilder, IDocumentStore> storeCreator)
         {
             DocumentStoreManager.SetDocumentStore<StorageType.Timeouts>(cfg.GetSettings(), storeCreator);
             return cfg;


### PR DESCRIPTION
because of the different Func overloads with the same amount of parameters, there can be compiler errors in case the passed functions don't clearly define which type it uses (e.g. by passing something like `_ => return new Foo()`. To avoid this, the newly added extensions providing access to the IBuilder are an additional overload so there isn't any ambiguity.