### PR TITLE
Repro Timeout data conversion bug

### DIFF
--- a/src/NServiceBus.RavenDB.Tests/Infrastructure/ReusableDB.cs
+++ b/src/NServiceBus.RavenDB.Tests/Infrastructure/ReusableDB.cs
@@ -31,7 +31,7 @@
             Console.WriteLine($"Provisioned new Raven database name {databaseName}");
         }
 
-        public IDocumentStore NewStore(string identifier = null)
+        public DocumentStore NewStore(string identifier = null)
         {
             Console.WriteLine();
             Console.WriteLine($"Creating new DocumentStore for {databaseName}");
@@ -45,7 +45,7 @@
             return store;
         }
 
-        private IDocumentStore CreateStore()
+        private DocumentStore CreateStore()
         {
             return new DocumentStore
             {

--- a/src/NServiceBus.RavenDB.Tests/LegacyAddress.cs
+++ b/src/NServiceBus.RavenDB.Tests/LegacyAddress.cs
@@ -1,0 +1,128 @@
+namespace NServiceBus.RavenDB.Tests
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    [Serializable]
+    class LegacyAddress : ISerializable
+    {
+        public LegacyAddress(string queueName, string machineName, bool ignoreMachineName = false, string defaultMachineName = "")
+        {
+            Queue = queueName;
+            queueLowerCased = queueName.ToLower();
+            Machine = machineName ?? defaultMachineName;
+            machineLowerCased = Machine.ToLower();
+            this.ignoreMachineName = ignoreMachineName;
+        }
+
+        protected LegacyAddress(SerializationInfo info, StreamingContext context)
+        {
+            Queue = info.GetString("Queue");
+            Machine = info.GetString("Machine");
+
+            if (!string.IsNullOrEmpty(Queue))
+            {
+                queueLowerCased = Queue.ToLower();
+            }
+
+            if (!string.IsNullOrEmpty(Machine))
+            {
+                machineLowerCased = Machine.ToLower();
+            }
+        }
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue("Queue", Queue);
+            info.AddValue("Machine", Machine);
+        }
+
+        public LegacyAddress SubScope(string qualifier)
+        {
+            return new LegacyAddress(Queue + "." + qualifier, Machine);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = ((queueLowerCased?.GetHashCode() ?? 0) * 397);
+
+                if (!ignoreMachineName)
+                {
+                    hashCode ^= machineLowerCased?.GetHashCode() ?? 0;
+                }
+                return hashCode;
+            }
+        }
+
+        public override string ToString()
+        {
+            if (ignoreMachineName)
+                return Queue;
+
+            return Queue + "@" + Machine;
+        }
+
+        public string Queue { get; }
+
+        public string Machine { get; }
+
+        /// <summary>
+        /// Overloading for the == for the class LegacyAddress
+        /// </summary>
+        /// <param name="left">Left hand side of == operator</param>
+        /// <param name="right">Right hand side of == operator</param>
+        /// <returns>true if the LHS is equal to RHS</returns>
+        public static bool operator ==(LegacyAddress left, LegacyAddress right)
+        {
+            return Equals(left, right);
+        }
+
+        /// <summary>
+        /// Overloading for the != for the class LegacyAddress
+        /// </summary>
+        /// <param name="left">Left hand side of != operator</param>
+        /// <param name="right">Right hand side of != operator</param>
+        /// <returns>true if the LHS is not equal to RHS</returns>
+        public static bool operator !=(LegacyAddress left, LegacyAddress right)
+        {
+            return !Equals(left, right);
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="object"/>.
+        /// </summary>
+        /// <returns>
+        /// true if the specified <see cref="object"/> is equal to the current <see cref="object"/>; otherwise, false.
+        /// </returns>
+        /// <param name="obj">The <see cref="object"/> to compare with the current <see cref="object"/>. </param><filterpriority>2</filterpriority>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != typeof(LegacyAddress)) return false;
+            return Equals((LegacyAddress)obj);
+        }
+
+        /// <summary>
+        /// Check this is equal to other LegacyAddress
+        /// </summary>
+        /// <param name="other">reference addressed to be checked with this</param>
+        /// <returns>true if this is equal to other</returns>
+        bool Equals(LegacyAddress other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            if (!ignoreMachineName && !other.machineLowerCased.Equals(machineLowerCased))
+                return false;
+
+            return other.queueLowerCased.Equals(queueLowerCased);
+        }
+
+        readonly string queueLowerCased;
+        readonly string machineLowerCased;
+        bool ignoreMachineName;
+    }
+}

--- a/src/NServiceBus.RavenDB.Tests/RavenDBPersistenceTestBase.cs
+++ b/src/NServiceBus.RavenDB.Tests/RavenDBPersistenceTestBase.cs
@@ -20,7 +20,7 @@
             this.store = docStore;
         }
 
-        protected virtual void CustomizeDocumentStore(IDocumentStore docStore)
+        protected virtual void CustomizeDocumentStore(DocumentStore docStore)
         {
         }
 
@@ -68,7 +68,7 @@
         }
 
         List<IAsyncDocumentSession> sessions = new List<IAsyncDocumentSession>();
-        protected IDocumentStore store;
+        protected DocumentStore store;
         ReusableDB db;
 
         internal IOpenRavenSessionsInPipeline CreateTestSessionOpener()

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_loading_Raven3_sagas.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_loading_Raven3_sagas.cs
@@ -16,9 +16,9 @@ using Raven.Client.Json;
 // This class name is important - it's simple to make it easier to insert fake Raven3.x-like saga data
 class Raven3Sagas : RavenDBPersistenceTestBase
 {
-    protected override void CustomizeDocumentStore(IDocumentStore docStore)
+    protected override void CustomizeDocumentStore(DocumentStore docStore)
     {
-        UnwrappedSagaListener.Register(docStore as DocumentStore);
+        UnwrappedSagaListener.Register(docStore);
     }
 
     [Test]

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_loading_a_legacy_unique_identity.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_loading_a_legacy_unique_identity.cs
@@ -15,9 +15,9 @@ using Raven.Client.Json;
 [TestFixture]
 class When_loading_a_saga_with_legacy_unique_identity : RavenDBPersistenceTestBase
 {
-    protected override void CustomizeDocumentStore(IDocumentStore store)
+    protected override void CustomizeDocumentStore(DocumentStore store)
     {
-        UnwrappedSagaListener.Register(store as DocumentStore);
+        UnwrappedSagaListener.Register(store);
     }
 
     [Test]

--- a/src/NServiceBus.RavenDB.Tests/Timeouts/LegacyTimeoutData.cs
+++ b/src/NServiceBus.RavenDB.Tests/Timeouts/LegacyTimeoutData.cs
@@ -1,0 +1,28 @@
+namespace NServiceBus.RavenDB.Tests.Timeouts
+{
+    using System;
+    using System.Collections.Generic;
+
+    class LegacyTimeoutData
+    {
+        /// <summary>
+        ///     Id of this timeout
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        ///     The address of the client who requested the timeout.
+        /// </summary>
+        public LegacyAddress Destination { get; set; }
+
+        public Guid SagaId { get; set; }
+
+        public byte[] State { get; set; }
+
+        public DateTime Time { get; set; }
+
+        public string OwningTimeoutManager { get; set; }
+
+        public Dictionary<string, string> Headers { get; set; }
+    }
+}

--- a/src/NServiceBus.RavenDB.Tests/Timeouts/When_converting_old_timeout_to_new_timeout.cs
+++ b/src/NServiceBus.RavenDB.Tests/Timeouts/When_converting_old_timeout_to_new_timeout.cs
@@ -1,0 +1,178 @@
+namespace NServiceBus.RavenDB.Tests.Timeouts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
+    using NServiceBus.Persistence.RavenDB;
+    using NServiceBus.Support;
+    using NUnit.Framework;
+    using Raven.Client;
+    using Sparrow.Json;
+    using Sparrow.Json.Parsing;
+    using LegacyAddress = NServiceBus.RavenDB.Tests.LegacyAddress;
+    using TimeoutData = NServiceBus.Timeout.Core.TimeoutData;
+
+    [TestFixture]
+    public class When_converting_old_timeout_to_new_timeout : RavenDBPersistenceTestBase
+    {
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            store.OnAfterConversionToDocument += (sender, args) =>
+            {
+                var metadata = args.Session.GetMetadataFor(args.Entity);
+                metadata[Constants.Documents.Metadata.RavenClrType] = "NServiceBus.TimeoutPersisters.RavenDB.TimeoutData, NServiceBus.RavenDB";
+                metadata[Constants.Documents.Metadata.Collection] = "TimeoutDatas";
+            };
+            // uncomment below to make the tests pass
+            // store.OnBeforeConversionToEntity += (sender, args) =>
+            // {
+            //     if (args.Type != typeof(NServiceBus.TimeoutPersisters.RavenDB.TimeoutData))
+            //     {
+            //         return;
+            //     }
+            //
+            //     if (!args.Document.TryGetMember("Destination", out var destination))
+            //     {
+            //         return;
+            //     }
+            //     
+            //     var innerReader = destination as BlittableJsonReaderObject;
+            //     if (innerReader?.Count != 2)
+            //     {
+            //         return;
+            //     }
+            //     
+            //     innerReader.TryGet("Queue", out string queue);
+            //     innerReader.TryGet("Machine", out string machine);
+            //
+            //     // Previously known as IgnoreMachineName (for brokers)
+            //     var replacement = queue;
+            //     if (!string.IsNullOrEmpty(machine))
+            //     {
+            //         replacement = queue + "@" + machine;
+            //     }
+            //
+            //     if (args.Document.Modifications == null)
+            //     {
+            //         args.Document.Modifications = new DynamicJsonValue();
+            //     }
+            //                     
+            //     args.Document.Modifications["Destination"] = replacement;
+            //                 
+            //     args.Document = args.Session.Context.ReadObject(args.Document, args.Id);
+            // };
+
+            persister = new TimeoutPersister(store);
+        }
+
+        [Test]
+        public async Task Should_allow_old_timeouts()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                {"Bar", "34234"},
+                {"Foo", "aString1"},
+                {"Super", "aString2"}
+            };
+
+            var timeout = new LegacyTimeoutData
+            {
+                Time = DateTime.UtcNow.AddHours(-1),
+                Destination = new LegacyAddress("timeouts", RuntimeEnvironment.MachineName),
+                SagaId = Guid.NewGuid(),
+                State = new byte[]
+                {
+                    1,
+                    1,
+                    133,
+                    200
+                },
+                Headers = headers,
+                OwningTimeoutManager = "MyTestEndpoint"
+            };
+            var context = new ContextBag();
+
+            var session = store.OpenAsyncSession();
+            await session.StoreAsync(timeout);
+            await session.SaveChangesAsync();
+
+            Assert.True(await persister.TryRemove(timeout.Id, context));
+        }
+
+        [Test]
+        public async Task Should_allow_old_timeouts_without_machine_name()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                {"Bar", "34234"},
+                {"Foo", "aString1"},
+                {"Super", "aString2"}
+            };
+
+            var timeout = new LegacyTimeoutData
+            {
+                Time = DateTime.UtcNow.AddHours(-1),
+                Destination = new LegacyAddress("timeouts", null),
+                SagaId = Guid.NewGuid(),
+                State = new byte[]
+                {
+                    1,
+                    1,
+                    133,
+                    200
+                },
+                Headers = headers,
+                OwningTimeoutManager = "MyTestEndpoint"
+            };
+            var context = new ContextBag();
+
+            var session = store.OpenAsyncSession();
+            await session.StoreAsync(timeout);
+            await session.SaveChangesAsync();
+
+            Assert.True(await persister.TryRemove(timeout.Id, context));
+        }
+
+        [Test]
+        // This test makes sure that the conversion listener doesn't destroy new documents
+        public async Task Should_allow_new_timeouts()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                {"Bar", "34234"},
+                {"Foo", "aString1"},
+                {"Super", "aString2"}
+            };
+
+            var timeout = new TimeoutData
+            {
+                Time = DateTime.UtcNow.AddHours(-1),
+                Destination = "timeouts" + "@" + RuntimeEnvironment.MachineName,
+                SagaId = Guid.NewGuid(),
+                State = new byte[]
+                {
+                    1,
+                    1,
+                    133,
+                    200
+                },
+                Headers = headers,
+                OwningTimeoutManager = "MyTestEndpoint"
+            };
+
+            var session = store.OpenAsyncSession();
+            await session.StoreAsync(timeout);
+            await session.SaveChangesAsync();
+            var context = new ContextBag();
+
+            var retrievedTimeout = await persister.Peek(timeout.Id, context);
+
+            Assert.AreEqual(timeout.Destination, retrievedTimeout.Destination);
+        }
+
+        TimeoutPersister persister;
+    }
+}


### PR DESCRIPTION
Old timeouts are stored in the following JSON format

```
{
    "Destination": {
        "Queue": "timeouts",
        "Machine": "BF108680"
    },
    "SagaId": "ee42f0c4-0c36-4c97-bd8f-04cc9a0fb158",
    "State": "AQGFyA==",
    "Time": "2020-03-02T12:08:45.6537507Z",
    "OwningTimeoutManager": "MyTestEndpoint",
    "Headers": {
        "Bar": "34234",
        "Foo": "aString1",
        "Super": "aString2"
    },
    "@metadata": {
        "@collection": "TimeoutDatas",
        "Raven-Clr-Type": "NServiceBus.TimeoutPersisters.RavenDB.TimeoutData, NServiceBus.RavenDB"
    }
}
```

new timeouts have the following format

```
{
    "Destination": "timeouts@BF108680",
    "SagaId": "ee42f0c4-0c36-4c97-bd8f-04cc9a0fb158",
    "State": "AQGFyA==",
    "Time": "2020-03-02T12:08:45.6537507Z",
    "OwningTimeoutManager": "MyTestEndpoint",
    "Headers": {
        "Bar": "34234",
        "Foo": "aString1",
        "Super": "aString2"
    },
    "@metadata": {
        "@collection": "TimeoutDatas",
        "Raven-Clr-Type": "NServiceBus.TimeoutPersisters.RavenDB.TimeoutData, NServiceBus.RavenDB"
    }
}
```

any attempt to load a previous format will fail. Because the nested type 

```
    "Destination": {
        "Queue": "timeouts",
        "Machine": "BF108680"
    },
```

cannot be converted into a flat destination automatically

The following patch would migrate all old timeouts into the new format

```
from TimeoutDatas  
update { 
    if(!this.Destination.Machine) {
        this.Destination = this.Destination.Queue
    }
    else {
        this.Destination = this.Destination.Queue + "@" + this.Destination.Machine
    }
}
```