### PR TITLE
Make connection string discovery easier using local database/containers

### DIFF
--- a/src/NServiceBus.RavenDB.AcceptanceTests/ConfigureEndpointRavenDBPersistence.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/ConfigureEndpointRavenDBPersistence.cs
@@ -51,11 +51,7 @@ public class ConfigureEndpointRavenDBPersistence : IConfigureEndpointTestExecuti
 
     internal static DocumentStore GetInitializedDocumentStore(string defaultDatabase)
     {
-        var urls = Environment.GetEnvironmentVariable("CommaSeparatedRavenClusterUrls");
-        if (urls == null)
-        {
-            throw new Exception("RavenDB cluster URLs must be specified in an environment variable named CommaSeparatedRavenClusterUrls.");
-        }
+        var urls = Environment.GetEnvironmentVariable("CommaSeparatedRavenClusterUrls") ?? "http://localhost:8080";
 
         var documentStore = new DocumentStore
         {

--- a/src/NServiceBus.RavenDB.Tests/TestConstants.cs
+++ b/src/NServiceBus.RavenDB.Tests/TestConstants.cs
@@ -8,12 +8,7 @@
         {
             get
             {
-                var urls = Environment.GetEnvironmentVariable("CommaSeparatedRavenClusterUrls");
-                if (urls == null)
-                {
-                    throw new Exception("RavenDB cluster URLs must be specified in an environment variable named CommaSeparatedRavenClusterUrls.");
-                }
-
+                var urls = Environment.GetEnvironmentVariable("CommaSeparatedRavenClusterUrls") ?? "http://localhost:8080";
                 return urls.Split(',');
             }
         }


### PR DESCRIPTION
Use a local connection string if no environment variable has been found to make it easier to run the tests locally against a local database (or typically a db running on a docker container)