### PR TITLE
Add startup diagnostics

### DIFF
--- a/src/NServiceBus.RavenDB/Outbox/RavenDBOutboxExtensions.cs
+++ b/src/NServiceBus.RavenDB/Outbox/RavenDBOutboxExtensions.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using NServiceBus.Configuration.AdvancedExtensibility;
+    using NServiceBus.Persistence.RavenDB;
 
     /// <summary>
     /// Contains extensions methods which allow to configure RavenDB outbox specific configuration
@@ -23,7 +24,7 @@
                 throw new ArgumentOutOfRangeException(nameof(timeToKeepDeduplicationData), "Specify a non-negative TimeSpan. The cleanup process removes entries older than the specified time to keep deduplication data, therefore the time span cannot be negative.");
             }
 
-            configuration.GetSettings().Set("Outbox.TimeToKeepDeduplicationData", timeToKeepDeduplicationData);
+            configuration.GetSettings().Set(RavenDbOutboxStorage.TimeToKeepDeduplicationData, timeToKeepDeduplicationData);
             return configuration;
         }
 
@@ -40,7 +41,7 @@
                 throw new ArgumentOutOfRangeException(nameof(frequencyToRunDeduplicationDataCleanup), "Provide a non-negative TimeSpan to specify cleanup task execution frequency or specify System.Threading.Timeout.InfiniteTimeSpan to disable cleanup.");
             }
 
-            configuration.GetSettings().Set("Outbox.FrequencyToRunDeduplicationDataCleanup", frequencyToRunDeduplicationDataCleanup);
+            configuration.GetSettings().Set(RavenDbOutboxStorage.FrequencyToRunDeduplicationDataCleanup, frequencyToRunDeduplicationDataCleanup);
             return configuration;
         }
     }

--- a/src/NServiceBus.RavenDB/Outbox/RavenDbOutboxStorage.cs
+++ b/src/NServiceBus.RavenDB/Outbox/RavenDbOutboxStorage.cs
@@ -25,8 +25,8 @@
                 return new OutboxPersister(endpointName, b.Build<IOpenTenantAwareRavenSessions>());
             }, DependencyLifecycle.InstancePerCall);
 
-            var frequencyToRunDeduplicationDataCleanup = context.Settings.GetOrDefault<TimeSpan?>("Outbox.FrequencyToRunDeduplicationDataCleanup") ?? TimeSpan.FromMinutes(1);
-            var timeToKeepDeduplicationData = context.Settings.GetOrDefault<TimeSpan?>("Outbox.TimeToKeepDeduplicationData") ?? TimeSpan.FromDays(7);
+            var frequencyToRunDeduplicationDataCleanup = context.Settings.GetOrDefault<TimeSpan?>(FrequencyToRunDeduplicationDataCleanup) ?? TimeSpan.FromMinutes(1);
+            var timeToKeepDeduplicationData = context.Settings.GetOrDefault<TimeSpan?>(TimeToKeepDeduplicationData) ?? TimeSpan.FromDays(7);
 
             context.RegisterStartupTask(builder =>
             {
@@ -42,6 +42,9 @@
                     TimeToKeepDeduplicationData = timeToKeepDeduplicationData,
                 });
         }
+
+        internal const string TimeToKeepDeduplicationData = "Outbox.TimeToKeepDeduplicationData";
+        internal const string FrequencyToRunDeduplicationDataCleanup = "Outbox.FrequencyToRunDeduplicationDataCleanup";
 
         class OutboxCleaner : FeatureStartupTask
         {

--- a/src/NServiceBus.RavenDB/RavenDbSettingsExtensions.cs
+++ b/src/NServiceBus.RavenDB/RavenDbSettingsExtensions.cs
@@ -14,8 +14,6 @@
     /// </summary>
     public static class RavenDbSettingsExtensions
     {
-        internal const string SharedAsyncSessionSettingsKey = "RavenDbSharedAsyncSession";
-
         /// <summary>
         ///     Configures the storages to use the given document store supplied
         /// </summary>
@@ -80,7 +78,7 @@
             {
                 throw new ArgumentNullException(nameof(getAsyncSessionFunc));
             }
-            cfg.GetSettings().Set(SharedAsyncSessionSettingsKey, getAsyncSessionFunc);
+            cfg.GetSettings().Set(RavenDbStorageSession.SharedAsyncSession, getAsyncSessionFunc);
             return cfg;
         }
 
@@ -95,7 +93,7 @@
         /// <returns>The configuration object.</returns>
         public static PersistenceExtensions<RavenDBPersistence> SetMessageToDatabaseMappingConvention(this PersistenceExtensions<RavenDBPersistence> cfg, Func<IDictionary<string,string>, string> convention)
         {
-            cfg.GetSettings().Set("RavenDB.SetMessageToDatabaseMappingConvention", convention);
+            cfg.GetSettings().Set(RavenDbStorageSession.MessageToDatabaseMappingConvention, convention);
             return cfg;
         }
 

--- a/src/NServiceBus.RavenDB/SessionManagement/RavenDbStorageSession.cs
+++ b/src/NServiceBus.RavenDB/SessionManagement/RavenDbStorageSession.cs
@@ -13,7 +13,7 @@
             context.Container.ConfigureComponent<RavenDBSynchronizedStorage>(DependencyLifecycle.SingleInstance);
 
             // Check to see if the user provided us with a shared session to work with before we go and create our own to inject into the pipeline
-            var getAsyncSessionFunc = context.Settings.GetOrDefault<Func<IDictionary<string, string>, IAsyncDocumentSession>>(RavenDbSettingsExtensions.SharedAsyncSessionSettingsKey);
+            var getAsyncSessionFunc = context.Settings.GetOrDefault<Func<IDictionary<string, string>, IAsyncDocumentSession>>(SharedAsyncSession);
 
             if (getAsyncSessionFunc != null)
             {
@@ -34,7 +34,7 @@
                     var store = DocumentStoreManager.GetDocumentStore<StorageType.Sagas>(context.Settings, b);
                     var storeWrapper = new DocumentStoreWrapper(store);
 
-                    var dbNameConvention = context.Settings.GetOrDefault<Func<IDictionary<string, string>, string>>("RavenDB.SetMessageToDatabaseMappingConvention");
+                    var dbNameConvention = context.Settings.GetOrDefault<Func<IDictionary<string, string>, string>>(MessageToDatabaseMappingConvention);
                     return new OpenRavenSessionByDatabaseName(storeWrapper, dbNameConvention);
                 }, DependencyLifecycle.SingleInstance);
 
@@ -43,11 +43,13 @@
                     new
                     {
                         HasSharedAsyncSession = false,
-                        HasMessageToDatabaseMappingConvention = context.Settings.HasSetting("RavenDB.SetMessageToDatabaseMappingConvention"),
+                        HasMessageToDatabaseMappingConvention = context.Settings.HasSetting(MessageToDatabaseMappingConvention),
                     });
             }
         }
 
+        internal const string SharedAsyncSession = "RavenDbSharedAsyncSession";
+        internal const string MessageToDatabaseMappingConvention = "RavenDB.SetMessageToDatabaseMappingConvention";
         const string StartupDiagnosticsSectionName = "NServiceBus.Persistence.RavenDB.StorageSession";
     }
 }

--- a/src/NServiceBus.RavenDB/SessionManagement/RavenDbStorageSession.cs
+++ b/src/NServiceBus.RavenDB/SessionManagement/RavenDbStorageSession.cs
@@ -29,14 +29,15 @@
             }
             else
             {
-                context.Container.ConfigureComponent<IOpenTenantAwareRavenSessions>(b =>
-                {
-                    var store = DocumentStoreManager.GetDocumentStore<StorageType.Sagas>(context.Settings, b);
-                    var storeWrapper = new DocumentStoreWrapper(store);
-
-                    var dbNameConvention = context.Settings.GetOrDefault<Func<IDictionary<string, string>, string>>(MessageToDatabaseMappingConvention);
-                    return new OpenRavenSessionByDatabaseName(storeWrapper, dbNameConvention);
-                }, DependencyLifecycle.SingleInstance);
+                context.Container.ConfigureComponent<IOpenTenantAwareRavenSessions>(
+                    builder =>
+                    {
+                        var store = DocumentStoreManager.GetDocumentStore<StorageType.Sagas>(context.Settings, builder);
+                        var storeWrapper = new DocumentStoreWrapper(store);
+                        var dbNameConvention = context.Settings.GetOrDefault<Func<IDictionary<string, string>, string>>(MessageToDatabaseMappingConvention);
+                        return new OpenRavenSessionByDatabaseName(storeWrapper, dbNameConvention);
+                    },
+                    DependencyLifecycle.SingleInstance);
 
                 context.Settings.AddStartupDiagnosticsSection(
                     StartupDiagnosticsSectionName,

--- a/src/NServiceBus.RavenDB/SessionManagement/RavenDbStorageSession.cs
+++ b/src/NServiceBus.RavenDB/SessionManagement/RavenDbStorageSession.cs
@@ -19,6 +19,13 @@
             {
                 IOpenTenantAwareRavenSessions sessionCreator = new OpenRavenSessionByCustomDelegate(getAsyncSessionFunc);
                 context.Container.RegisterSingleton(sessionCreator);
+
+                context.Settings.AddStartupDiagnosticsSection(
+                    StartupDiagnosticsSectionName,
+                    new
+                    {
+                        HasSharedAsyncSession = true,
+                    });
             }
             else
             {
@@ -30,7 +37,17 @@
                     var dbNameConvention = context.Settings.GetOrDefault<Func<IDictionary<string, string>, string>>("RavenDB.SetMessageToDatabaseMappingConvention");
                     return new OpenRavenSessionByDatabaseName(storeWrapper, dbNameConvention);
                 }, DependencyLifecycle.SingleInstance);
+
+                context.Settings.AddStartupDiagnosticsSection(
+                    StartupDiagnosticsSectionName,
+                    new
+                    {
+                        HasSharedAsyncSession = false,
+                        HasMessageToDatabaseMappingConvention = context.Settings.HasSetting("RavenDB.SetMessageToDatabaseMappingConvention"),
+                    });
             }
         }
+
+        const string StartupDiagnosticsSectionName = "NServiceBus.Persistence.RavenDB.StorageSession";
     }
 }

--- a/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionSettingsExtensions.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionSettingsExtensions.cs
@@ -12,9 +12,6 @@
     /// </summary>
     public static class RavenDbSubscriptionSettingsExtensions
     {
-        internal const string DoNotAggressivelyCacheSubscriptionsSettingsKey = "RavenDB.DoNotAggressivelyCacheSubscriptions";
-        internal const string AggressiveCacheDurationSettingsKey = "RavenDB.AggressiveCacheDuration";
-
         /// <summary>
         ///     Configures the given document store to be used when storing subscriptions
         /// </summary>
@@ -55,7 +52,7 @@
         /// </summary>
         public static PersistenceExtensions<RavenDBPersistence> DoNotCacheSubscriptions(this PersistenceExtensions<RavenDBPersistence> cfg)
         {
-            cfg.GetSettings().Set(DoNotAggressivelyCacheSubscriptionsSettingsKey, true);
+            cfg.GetSettings().Set(RavenDbSubscriptionStorage.DoNotCacheSubscriptions, true);
             return cfg;
         }
 
@@ -69,7 +66,7 @@
         /// <returns></returns>
         public static PersistenceExtensions<RavenDBPersistence> CacheSubscriptionsFor(this PersistenceExtensions<RavenDBPersistence> cfg, TimeSpan aggressiveCacheDuration)
         {
-            cfg.GetSettings().Set(AggressiveCacheDurationSettingsKey, aggressiveCacheDuration);
+            cfg.GetSettings().Set(RavenDbSubscriptionStorage.CacheSubscriptionsFor, aggressiveCacheDuration);
             return cfg;
         }
 

--- a/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionStorage.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionStorage.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using NServiceBus.Features;
-    using NServiceBus.Logging;
     using NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions;
 
     class RavenDbSubscriptionStorage : Feature
@@ -14,38 +13,38 @@
         protected override void Setup(FeatureConfigurationContext context)
         {
             var doNotCacheSubscriptions = context.Settings.GetOrDefault<bool>(DoNotCacheSubscriptions);
-            var gotCacheSubscriptionsFor = context.Settings.TryGet(CacheSubscriptionsFor, out TimeSpan aggressiveCacheDuration);
+            var gotCacheSubscriptionsFor = context.Settings.TryGet(CacheSubscriptionsFor, out TimeSpan cacheSubscriptionsFor);
 
             context.Settings.AddStartupDiagnosticsSection(
                 "NServiceBus.Persistence.RavenDB.Subscriptions",
                 new
                 {
                     DoNotCacheSubscriptions = doNotCacheSubscriptions,
-                    CacheSubscriptionsFor = aggressiveCacheDuration,
+                    CacheSubscriptionsFor = cacheSubscriptionsFor,
                 });
 
-            context.Container.ConfigureComponent<ISubscriptionStorage>(b =>
-            {
-                var store = DocumentStoreManager.GetDocumentStore<StorageType.Subscriptions>(context.Settings, b);
-
-                var persister = new SubscriptionPersister(store);
-
-                if (doNotCacheSubscriptions)
+            context.Container.ConfigureComponent<ISubscriptionStorage>(builder =>
                 {
-                    persister.DisableAggressiveCaching = true;
-                }
+                    var store = DocumentStoreManager.GetDocumentStore<StorageType.Subscriptions>(context.Settings, builder);
 
-                if (gotCacheSubscriptionsFor)
-                {
-                    persister.AggressiveCacheDuration = aggressiveCacheDuration;
-                }
+                    var persister = new SubscriptionPersister(store);
 
-                return persister;
-            }, DependencyLifecycle.SingleInstance);
+                    if (doNotCacheSubscriptions)
+                    {
+                        persister.DisableAggressiveCaching = true;
+                    }
+
+                    if (gotCacheSubscriptionsFor)
+                    {
+                        persister.AggressiveCacheDuration = cacheSubscriptionsFor;
+                    }
+
+                    return persister;
+                },
+                DependencyLifecycle.SingleInstance);
         }
 
         internal const string DoNotCacheSubscriptions = "RavenDB.DoNotAggressivelyCacheSubscriptions";
         internal const string CacheSubscriptionsFor = "RavenDB.AggressiveCacheDuration";
-        static readonly ILog Log = LogManager.GetLogger<RavenDbSubscriptionStorage>();
     }
 }

--- a/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionStorage.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionStorage.cs
@@ -13,7 +13,7 @@
         protected override void Setup(FeatureConfigurationContext context)
         {
             var doNotCacheSubscriptions = context.Settings.GetOrDefault<bool>(DoNotCacheSubscriptions);
-            var gotCacheSubscriptionsFor = context.Settings.TryGet(CacheSubscriptionsFor, out TimeSpan cacheSubscriptionsFor);
+            var cacheSubscriptionsFor = context.Settings.GetOrDefault<TimeSpan?>(CacheSubscriptionsFor) ?? TimeSpan.FromMinutes(1);
 
             context.Settings.AddStartupDiagnosticsSection(
                 "NServiceBus.Persistence.RavenDB.Subscriptions",
@@ -34,10 +34,7 @@
                         persister.DisableAggressiveCaching = true;
                     }
 
-                    if (gotCacheSubscriptionsFor)
-                    {
-                        persister.AggressiveCacheDuration = cacheSubscriptionsFor;
-                    }
+                    persister.AggressiveCacheDuration = cacheSubscriptionsFor;
 
                     return persister;
                 },

--- a/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionStorage.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionStorage.cs
@@ -13,8 +13,8 @@
 
         protected override void Setup(FeatureConfigurationContext context)
         {
-            var doNotCacheSubscriptions = context.Settings.GetOrDefault<bool>(RavenDbSubscriptionSettingsExtensions.DoNotAggressivelyCacheSubscriptionsSettingsKey);
-            var gotCacheSubscriptionsFor = context.Settings.TryGet(RavenDbSubscriptionSettingsExtensions.AggressiveCacheDurationSettingsKey, out TimeSpan aggressiveCacheDuration);
+            var doNotCacheSubscriptions = context.Settings.GetOrDefault<bool>(DoNotCacheSubscriptions);
+            var gotCacheSubscriptionsFor = context.Settings.TryGet(CacheSubscriptionsFor, out TimeSpan aggressiveCacheDuration);
 
             context.Settings.AddStartupDiagnosticsSection(
                 "NServiceBus.Persistence.RavenDB.Subscriptions",
@@ -44,6 +44,8 @@
             }, DependencyLifecycle.SingleInstance);
         }
 
+        internal const string DoNotCacheSubscriptions = "RavenDB.DoNotAggressivelyCacheSubscriptions";
+        internal const string CacheSubscriptionsFor = "RavenDB.AggressiveCacheDuration";
         static readonly ILog Log = LogManager.GetLogger<RavenDbSubscriptionStorage>();
     }
 }

--- a/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionStorage.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionStorage.cs
@@ -27,16 +27,11 @@
                 {
                     var store = DocumentStoreManager.GetDocumentStore<StorageType.Subscriptions>(context.Settings, builder);
 
-                    var persister = new SubscriptionPersister(store);
-
-                    if (doNotCacheSubscriptions)
+                    return new SubscriptionPersister(store)
                     {
-                        persister.DisableAggressiveCaching = true;
-                    }
-
-                    persister.AggressiveCacheDuration = cacheSubscriptionsFor;
-
-                    return persister;
+                        DisableAggressiveCaching = doNotCacheSubscriptions,
+                        AggressiveCacheDuration = cacheSubscriptionsFor,
+                    };
                 },
                 DependencyLifecycle.SingleInstance);
         }

--- a/src/NServiceBus.RavenDB/Subscriptions/SubscriptionPersister.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/SubscriptionPersister.cs
@@ -22,7 +22,7 @@ namespace NServiceBus.Persistence.RavenDB
             documentStore = store;
         }
 
-        public TimeSpan AggressiveCacheDuration { get; set; } = TimeSpan.FromMinutes(1);
+        public TimeSpan AggressiveCacheDuration { get; set; }
 
         public bool DisableAggressiveCaching { get; set; }
 


### PR DESCRIPTION
Closes #362

- [x] Outbox
~- [ ] Sagas~
~- [ ] Gateway~
- [x] Subscriptions
- [x] Timeouts
- [x] Session

Additional information

- Followed the pattern that we use in other repositories as well of declaring the settings keys where they are used (which is in the features)