### PR TITLE
Obsolete DoNotSetupDatabasePermissions

### DIFF
--- a/src/NServiceBus.RavenDB.AcceptanceTests/ConfigureEndpointRavenDBPersistence.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/ConfigureEndpointRavenDBPersistence.cs
@@ -23,7 +23,6 @@ public class ConfigureEndpointRavenDBPersistence : IConfigureEndpointTestExecuti
 
         var persistenceExtensions = configuration.UsePersistence<RavenDBPersistence>()
             .DoNotCacheSubscriptions()
-            .DoNotSetupDatabasePermissions()
             .SetDefaultDocumentStore(documentStore);
 
         configuration.GetSettings().Set(DefaultPersistenceExtensionsKey, persistenceExtensions);

--- a/src/NServiceBus.RavenDB.AcceptanceTests/ConfigureRavenDBGatewayPersitence.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/ConfigureRavenDBGatewayPersitence.cs
@@ -16,7 +16,6 @@
 #pragma warning disable 618
             configuration.UsePersistence<RavenDBPersistence, StorageType.GatewayDeduplication>()
 #pragma warning restore 618
-                .DoNotSetupDatabasePermissions()
                 .SetDefaultDocumentStore(documentStore);
 
             return Task.FromResult(0);

--- a/src/NServiceBus.RavenDB.AcceptanceTests/GatewayTestSuiteConstraints.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/GatewayTestSuiteConstraints.cs
@@ -17,7 +17,6 @@
 #pragma warning disable 618
             configuration.UsePersistence<RavenDBPersistence, StorageType.GatewayDeduplication>()
 #pragma warning restore 618
-                .DoNotSetupDatabasePermissions()
                 .SetDefaultDocumentStore(documentStore);
 
             var gatewaySettings = configuration.Gateway();

--- a/src/NServiceBus.RavenDB.Tests/ApprovalFiles/APIApprovals.ApproveRavenDBPersistence.approved.txt
+++ b/src/NServiceBus.RavenDB.Tests/ApprovalFiles/APIApprovals.ApproveRavenDBPersistence.approved.txt
@@ -54,6 +54,9 @@ namespace NServiceBus
     }
     public class static RavenDbSettingsExtensions
     {
+        [System.ObsoleteAttribute("Database permissions are no longer set up, so this method has no effect. All call" +
+            "s to this method may be safely removed. The member currently throws a NotImpleme" +
+            "ntedException. Will be removed in version 7.0.0.", true)]
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> DoNotSetupDatabasePermissions(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> SetDefaultDocumentStore(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, Raven.Client.Documents.IDocumentStore documentStore) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> SetDefaultDocumentStore(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.Settings.ReadOnlySettings, Raven.Client.Documents.IDocumentStore> storeCreator) { }

--- a/src/NServiceBus.RavenDB/RavenDbSettingsExtensions.cs
+++ b/src/NServiceBus.RavenDB/RavenDbSettingsExtensions.cs
@@ -104,10 +104,13 @@
         /// </summary>
         /// <param name="cfg"></param>
         /// <returns></returns>
+        [ObsoleteEx(
+            Message = "Database permissions are no longer set up, so this method has no effect. All calls to this method may be safely removed.",
+            RemoveInVersion = "7.0.0",
+            TreatAsErrorFromVersion = "6.0.0")]
         public static PersistenceExtensions<RavenDBPersistence> DoNotSetupDatabasePermissions(this PersistenceExtensions<RavenDBPersistence> cfg)
         {
-            cfg.GetSettings().Set("RavenDB.DoNotSetupPermissions", true);
-            return cfg;
+            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
The method was no longer effective since `3.2`