### PR TITLE
Dispose the session in case it is owned by the RavenDBSynchronizedStorageSession and not by the outbox

### DIFF
--- a/src/NServiceBus.RavenDB/SessionManagement/RavenDBSynchronizedStorageSession.cs
+++ b/src/NServiceBus.RavenDB/SessionManagement/RavenDBSynchronizedStorageSession.cs
@@ -15,6 +15,10 @@ namespace NServiceBus.Persistence.RavenDB
 
         public void Dispose()
         {
+            if (callSaveChanges)
+            {
+                Session.Dispose();
+            }
         }
 
         public Task CompleteAsync()


### PR DESCRIPTION
Backport of #521 to `release-6.3`