### PR TITLE
Update NSB to 7.4

### DIFF
--- a/src/NServiceBus.RavenDB.AcceptanceTests/NServiceBus.RavenDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/NServiceBus.RavenDB.AcceptanceTests.csproj
@@ -11,9 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NServiceBus" Version="7.3.0" />
     <PackageReference Include="NServiceBus.Gateway.AcceptanceTests.Sources" Version="3.0.2" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.3.0" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.4.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="RavenDB.Client" Version="4.2.103" />

--- a/src/NServiceBus.RavenDB.PessimisticLock.AcceptanceTests/NServiceBus.RavenDB.PessimisticLock.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.PessimisticLock.AcceptanceTests/NServiceBus.RavenDB.PessimisticLock.AcceptanceTests.csproj
@@ -12,8 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NServiceBus" Version="7.3.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.3.0" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.4.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="RavenDB.Client" Version="4.2.103" />

--- a/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
+++ b/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NServiceBus" Version="7.3.0" />
+    <PackageReference Include="NServiceBus" Version="7.4.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Particular.Approvals" Version="0.2.0" />


### PR DESCRIPTION
 - Removing reference to NSB from test projects 
 - update reference to NSB.Att.Sources to 7.4