### PR TITLE
Default to pessimistic locking

### DIFF
--- a/src/NServiceBus.RavenDB.AcceptanceTests/ConfigureEndpointRavenDBPersistence.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/ConfigureEndpointRavenDBPersistence.cs
@@ -25,6 +25,8 @@ public class ConfigureEndpointRavenDBPersistence : IConfigureEndpointTestExecuti
             .DoNotCacheSubscriptions()
             .SetDefaultDocumentStore(documentStore);
 
+        persistenceExtensions.Sagas().UseOptimisticLocking();
+
         configuration.GetSettings().Set(DefaultPersistenceExtensionsKey, persistenceExtensions);
 
         Console.WriteLine("Created '{0}' database", documentStore.Database);

--- a/src/NServiceBus.RavenDB.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.RavenDB.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -18,9 +18,8 @@
         static PersistenceTestsConfiguration()
         {
             var optimisticConcurrencyConfiguration = new SagaPersistenceConfiguration();
-            optimisticConcurrencyConfiguration.UsePessimisticLocking(false);
+            optimisticConcurrencyConfiguration.UseOptimisticLocking();
             var pessimisticLockingConfiguration = new SagaPersistenceConfiguration();
-            pessimisticLockingConfiguration.UsePessimisticLocking(true);
 
             SagaVariants = new[]
             {

--- a/src/NServiceBus.RavenDB.PessimisticLock.AcceptanceTests/ConfigureEndpointRavenDBPersistence.cs
+++ b/src/NServiceBus.RavenDB.PessimisticLock.AcceptanceTests/ConfigureEndpointRavenDBPersistence.cs
@@ -25,9 +25,6 @@ public class ConfigureEndpointRavenDBPersistence : IConfigureEndpointTestExecuti
             .DoNotCacheSubscriptions()
             .SetDefaultDocumentStore(documentStore);
 
-        var sagasConfiguration = persistenceExtensions.Sagas();
-        sagasConfiguration.UsePessimisticLocking();
-
         configuration.GetSettings().Set(DefaultPersistenceExtensionsKey, persistenceExtensions);
 
         Console.WriteLine("Created '{0}' database", documentStore.Database);

--- a/src/NServiceBus.RavenDB.PessimisticLock.AcceptanceTests/When_storing_saga_with_high_contention.cs
+++ b/src/NServiceBus.RavenDB.PessimisticLock.AcceptanceTests/When_storing_saga_with_high_contention.cs
@@ -18,7 +18,7 @@ namespace NServiceBus.RavenDB.AcceptanceTests
             var scenario = await Scenario.Define<HighContentionScenario>()
                 .WithEndpoint<HighContentionEndpoint>(behavior =>
                 {
-                    behavior.CustomConfig(configuration => configuration.UsePersistence<RavenDBPersistence>().Sagas().UsePessimisticLocking(true));
+                    behavior.CustomConfig(configuration => configuration.UsePersistence<RavenDBPersistence>().Sagas());
                     behavior.When(session => session.SendLocal(new StartSaga { SomeId = Guid.NewGuid() }));
                 })
                 .Done(s => s.SagaCompleted)

--- a/src/NServiceBus.RavenDB.Tests/ApprovalFiles/APIApprovals.ApproveRavenDBPersistence.approved.txt
+++ b/src/NServiceBus.RavenDB.Tests/ApprovalFiles/APIApprovals.ApproveRavenDBPersistence.approved.txt
@@ -13,6 +13,9 @@ namespace NServiceBus.Persistence.RavenDB
         public void SetPessimisticLeaseLockAcquisitionMaximumRefreshDelay(System.TimeSpan value) { }
         public void SetPessimisticLeaseLockAcquisitionTimeout(System.TimeSpan value) { }
         public void SetPessimisticLeaseLockTime(System.TimeSpan value) { }
+        public void UseOptimisticLocking() { }
+        [System.Obsolete("Pessimistic locking is now the default, to enable optimistic locking, use UseOpti" +
+            "misticLocking(). Will be removed in version 8.0.0.", true)]
         public void UsePessimisticLocking(bool value = true) { }
     }
 }

--- a/src/NServiceBus.RavenDB/SagaPersister/SagaPersistenceConfiguration.cs
+++ b/src/NServiceBus.RavenDB/SagaPersister/SagaPersistenceConfiguration.cs
@@ -5,15 +5,14 @@
     /// <summary>
     /// The saga persistence configuration options.
     /// </summary>
-    public class SagaPersistenceConfiguration
+    public partial class SagaPersistenceConfiguration
     {
         /// <summary>
         /// Enables or disables default saga persistence pessimistic locking. Default to optimistic locking when not used.
         /// </summary>
-        /// <param name="value">True to enable pessimistic locking, otherwise optimistic locking.</param>
-        public void UsePessimisticLocking(bool value = true)
+        public void UseOptimisticLocking()
         {
-            EnablePessimisticLocking = value;
+            EnablePessimisticLocking = false;
         }
 
         /// <summary>
@@ -64,6 +63,6 @@
         internal TimeSpan LeaseLockAcquisitionTimeout { get; private set; } = TimeSpan.FromSeconds(60);
         internal TimeSpan LeaseLockTime { get; private set; } = TimeSpan.FromSeconds(60);
         internal TimeSpan LeaseLockAcquisitionMaximumRefreshDelay { get; private set; } = TimeSpan.FromMilliseconds(20);
-        internal bool EnablePessimisticLocking { get; private set; }
+        internal bool EnablePessimisticLocking { get; private set; } = true;
     }
 }

--- a/src/NServiceBus.RavenDB/obsoletes-v7.cs
+++ b/src/NServiceBus.RavenDB/obsoletes-v7.cs
@@ -27,3 +27,21 @@ namespace NServiceBus
         }
     }
 }
+
+namespace NServiceBus.Persistence.RavenDB
+{
+    using System;
+
+    partial class SagaPersistenceConfiguration
+    {
+        [ObsoleteEx(
+            Message = "Pessimistic locking is now the default, to enable optimistic locking, use UseOptimisticLocking().",
+            TreatAsErrorFromVersion = "7",
+            RemoveInVersion = "8"
+        )]
+        public void UsePessimisticLocking(bool value = true)
+        {
+            throw new InvalidOperationException();
+        }
+    }
+}


### PR DESCRIPTION
PR for https://github.com/Particular/NServiceBus.RavenDB/issues/538 which defaults the locking behavior to pessimistic locking and provides a new method to enable optimistic locking.