### PR TITLE
Cluster-wide Transactions support

### DIFF
--- a/src/NServiceBus.RavenDB.ClusterWideTx.AcceptanceTests/.editorconfig
+++ b/src/NServiceBus.RavenDB.ClusterWideTx.AcceptanceTests/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+
+# Justification: Test project
+dotnet_diagnostic.CA2007.severity = none

--- a/src/NServiceBus.RavenDB.ClusterWideTx.AcceptanceTests/ConfigureEndpointRavenDBPersistence.cs
+++ b/src/NServiceBus.RavenDB.ClusterWideTx.AcceptanceTests/ConfigureEndpointRavenDBPersistence.cs
@@ -26,6 +26,8 @@ public class ConfigureEndpointRavenDBPersistence : IConfigureEndpointTestExecuti
             .SetDefaultDocumentStore(documentStore)
             .UseClusterWideTransactions();
 
+        persistenceExtensions.Sagas().UseOptimisticLocking();
+
         configuration.GetSettings().Set(DefaultPersistenceExtensionsKey, persistenceExtensions);
 
         Console.WriteLine("Created '{0}' database", documentStore.Database);

--- a/src/NServiceBus.RavenDB.ClusterWideTx.AcceptanceTests/ConfigureEndpointRavenDBPersistence.cs
+++ b/src/NServiceBus.RavenDB.ClusterWideTx.AcceptanceTests/ConfigureEndpointRavenDBPersistence.cs
@@ -1,0 +1,138 @@
+﻿using NServiceBus;
+using NServiceBus.AcceptanceTesting.Support;
+using NServiceBus.Settings;
+using System;
+using System.Threading.Tasks;
+using NServiceBus.Configuration.AdvancedExtensibility;
+using Raven.Client.Documents;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+
+public class ConfigureEndpointRavenDBPersistence : IConfigureEndpointTestExecution
+{
+    const string DefaultDocumentStoreKey = "$.ConfigureEndpointRavenDBPersistence.DefaultDocumentStore";
+    const string DefaultPersistenceExtensionsKey = "$.ConfigureRavenDBPersistence.DefaultPersistenceExtensions";
+
+    public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings, PublisherMetadata publisherMetadata)
+    {
+        var documentStore = GetDocumentStore();
+
+        databaseName = documentStore.Database;
+
+        configuration.GetSettings().Set(DefaultDocumentStoreKey, documentStore);
+
+        var persistenceExtensions = configuration.UsePersistence<RavenDBPersistence>()
+            .DoNotCacheSubscriptions()
+            .SetDefaultDocumentStore(documentStore)
+            .UseClusterWideTransactions();
+
+        configuration.GetSettings().Set(DefaultPersistenceExtensionsKey, persistenceExtensions);
+
+        Console.WriteLine("Created '{0}' database", documentStore.Database);
+
+        return Task.FromResult(0);
+    }
+
+    public Task Cleanup()
+    {
+        return DeleteDatabase(databaseName);
+    }
+
+    public static DocumentStore GetDocumentStore()
+    {
+        var dbName = Guid.NewGuid().ToString();
+
+        var documentStore = GetInitializedDocumentStore(dbName);
+
+        CreateDatabase(documentStore, dbName);
+
+        return documentStore;
+    }
+
+    internal static DocumentStore GetInitializedDocumentStore(string defaultDatabase)
+    {
+        var urls = Environment.GetEnvironmentVariable("CommaSeparatedRavenClusterUrls") ?? "http://localhost:8080";
+
+        var documentStore = new DocumentStore
+        {
+            Urls = urls.Split(','),
+            Database = defaultDatabase
+        };
+
+        documentStore.Initialize();
+
+        return documentStore;
+    }
+
+    public static void CreateDatabase(IDocumentStore defaultStore, string dbName)
+    {
+        var dbRecord = new DatabaseRecord(dbName);
+        defaultStore.Maintenance.Server.Send(new CreateDatabaseOperation(dbRecord));
+    }
+
+    public static async Task DeleteDatabase(string dbName)
+    {
+        // Periodically the delete will throw an exception because Raven has the database locked
+        // To solve this we have a retry loop with a delay
+        var triesLeft = 3;
+
+        while (triesLeft-- > 0)
+        {
+            try
+            {
+                // We are using a new store because the global one is disposed of before cleanup
+                using (var storeForDeletion = GetInitializedDocumentStore(dbName))
+                {
+                    storeForDeletion.Maintenance.Server.Send(new DeleteDatabasesOperation(storeForDeletion.Database, hardDelete: true));
+                    break;
+                }
+            }
+            catch
+            {
+                if (triesLeft == 0)
+                {
+                    throw;
+                }
+
+                await Task.Delay(250);
+            }
+        }
+
+        Console.WriteLine("Deleted '{0}' database", dbName);
+    }
+
+    string databaseName;
+
+    public static DocumentStore GetDefaultDocumentStore(ReadOnlySettings settings)
+    {
+        return settings.Get<DocumentStore>(DefaultDocumentStoreKey);
+    }
+
+    public static PersistenceExtensions<RavenDBPersistence> GetDefaultPersistenceExtensions(ReadOnlySettings settings)
+    {
+        return settings.Get<PersistenceExtensions<RavenDBPersistence>>(DefaultPersistenceExtensionsKey);
+    }
+}
+
+public static class TestConfigurationExtensions
+{
+    public static PersistenceExtensions<RavenDBPersistence> ResetDocumentStoreSettings(this PersistenceExtensions<RavenDBPersistence> cfg, out TestDatabaseInfo dbInfo)
+    {
+        var settings = cfg.GetSettings();
+        var docStore = ConfigureEndpointRavenDBPersistence.GetDefaultDocumentStore(settings);
+
+        settings.Set("RavenDbDocumentStore", null);
+        dbInfo = new TestDatabaseInfo
+        {
+            Urls = docStore.Urls,
+            Database = docStore.Database
+        };
+        return cfg;
+    }
+}
+
+public class TestDatabaseInfo
+{
+    public string[] Urls { get; set; }
+    public string Database { get; set; }
+}

--- a/src/NServiceBus.RavenDB.ClusterWideTx.AcceptanceTests/NServiceBus.RavenDB.ClusterWideTx.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.ClusterWideTx.AcceptanceTests/NServiceBus.RavenDB.ClusterWideTx.AcceptanceTests.csproj
@@ -1,0 +1,51 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <RootNamespace>NServiceBus.RavenDB.AcceptanceTests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.RavenDB\NServiceBus.RavenDB.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0-alpha.644" />
+    <PackageReference Include="NUnit" Version="3.13.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="RavenDB.Client" Version="4.2.103" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\HasUnwrappedSagaListenerRegistered.cs">
+      <Link>HasUnwrappedSagaListenerRegistered.cs</Link>
+    </Compile>
+    <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\SagaAndOutbox.cs">
+      <Link>SagaAndOutbox.cs</Link>
+    </Compile>
+    <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\When_accessing_raven_session_from_handler_with_outbox.cs">
+      <Link>When_accessing_raven_session_from_handler_with_outbox.cs</Link>
+    </Compile>
+    <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\When_accessing_raven_session_from_handler_with_saga.cs">
+      <Link>When_accessing_raven_session_from_handler_with_saga.cs</Link>
+    </Compile>
+    <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\When_detecting_a_saga_with_multiple_corr_props.cs">
+      <Link>When_detecting_a_saga_with_multiple_corr_props.cs</Link>
+    </Compile>
+    <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\When_mixing_persistence_with_other_persistence_for_sagas_and_outbox.cs">
+      <Link>When_mixing_persistence_with_other_persistence_for_sagas_and_outbox.cs</Link>
+    </Compile>
+    <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\When_raven_session_is_provided.cs">
+      <Link>When_raven_session_is_provided.cs</Link>
+    </Compile>
+    <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\When_using_a_sagafinder.cs">
+      <Link>When_using_a_sagafinder.cs</Link>
+    </Compile>
+    <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\When_using_multitenant_dbs_with_Outbox.cs">
+      <Link>When_using_multitenant_dbs_with_Outbox.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+</Project>

--- a/src/NServiceBus.RavenDB.ClusterWideTx.AcceptanceTests/TestSuiteConstraints.cs
+++ b/src/NServiceBus.RavenDB.ClusterWideTx.AcceptanceTests/TestSuiteConstraints.cs
@@ -1,0 +1,21 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using AcceptanceTesting.Support;
+
+    public partial class TestSuiteConstraints
+    {
+        public bool SupportsDtc => false;
+
+        public bool SupportsCrossQueueTransactions => true;
+
+        public bool SupportsNativePubSub => false;
+
+        public bool SupportsDelayedDelivery => true;
+
+        public bool SupportsOutbox => true;
+
+        public IConfigureEndpointTestExecution CreateTransportConfiguration() => new ConfigureEndpointAcceptanceTestingTransport(SupportsNativePubSub, SupportsDelayedDelivery);
+
+        public IConfigureEndpointTestExecution CreatePersistenceConfiguration() => new ConfigureEndpointRavenDBPersistence();
+    }
+}

--- a/src/NServiceBus.RavenDB.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.RavenDB.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -72,17 +72,6 @@ namespace NServiceBus.PersistenceTesting
             var ravenConfiguration = Variant.Values[1] as PersistenceExtensions<RavenDBPersistence>;
             var settings = ravenConfiguration.GetSettings();
 
-            IOpenTenantAwareRavenSessions sessionCreator = new OpenRavenSessionByDatabaseName(new DocumentStoreWrapper(documentStore), settings);
-            SynchronizedStorage = new RavenDBSynchronizedStorage(sessionCreator);
-            SynchronizedStorageAdapter = new RavenDBSynchronizedStorageAdapter();
-
-            SupportsPessimisticConcurrency = sagaPersistenceConfiguration.EnablePessimisticLocking;
-            if (SessionTimeout.HasValue)
-            {
-                sagaPersistenceConfiguration.SetPessimisticLeaseLockAcquisitionTimeout(SessionTimeout.Value);
-            }
-            SagaStorage = new SagaPersister(sagaPersistenceConfiguration, sessionCreator);
-
             var dbName = Guid.NewGuid().ToString();
             var urls = Environment.GetEnvironmentVariable("CommaSeparatedRavenClusterUrls") ?? "http://localhost:8080";
             documentStore = new DocumentStore
@@ -93,6 +82,17 @@ namespace NServiceBus.PersistenceTesting
             documentStore.Initialize();
             var dbRecord = new DatabaseRecord(dbName);
             documentStore.Maintenance.Server.Send(new CreateDatabaseOperation(dbRecord));
+
+            IOpenTenantAwareRavenSessions sessionCreator = new OpenRavenSessionByDatabaseName(new DocumentStoreWrapper(documentStore), settings);
+            SynchronizedStorage = new RavenDBSynchronizedStorage(sessionCreator);
+            SynchronizedStorageAdapter = new RavenDBSynchronizedStorageAdapter();
+
+            SupportsPessimisticConcurrency = sagaPersistenceConfiguration.EnablePessimisticLocking;
+            if (SessionTimeout.HasValue)
+            {
+                sagaPersistenceConfiguration.SetPessimisticLeaseLockAcquisitionTimeout(SessionTimeout.Value);
+            }
+            SagaStorage = new SagaPersister(sagaPersistenceConfiguration, sessionCreator);
 
             OutboxStorage = new OutboxPersister(documentStore.Database, sessionCreator, RavenDbOutboxStorage.DeduplicationDataTTLDefault);
             return Task.CompletedTask;

--- a/src/NServiceBus.RavenDB.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.RavenDB.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -14,7 +14,6 @@ namespace NServiceBus.PersistenceTesting
     using Raven.Client.ServerWide;
     using Raven.Client.ServerWide.Operations;
     using Settings;
-    using Raven.Client.Documents.Session;
 
     public partial class PersistenceTestsConfiguration
     {
@@ -95,8 +94,7 @@ namespace NServiceBus.PersistenceTesting
             }
             SagaStorage = new SagaPersister(sagaPersistenceConfiguration, sessionCreator);
 
-            // TODO: Is this the right setting? 
-            var useClusterWideTx = ((InMemoryDocumentSessionOperations)documentStore.OpenSession()).TransactionMode == TransactionMode.ClusterWide;
+            var useClusterWideTx = settings.GetOrDefault<bool>(RavenDbStorageSession.UseClusterWideTransactions);
             OutboxStorage = new OutboxPersister(documentStore.Database, sessionCreator, RavenDbOutboxStorage.DeduplicationDataTTLDefault, useClusterWideTx);
             return Task.CompletedTask;
         }

--- a/src/NServiceBus.RavenDB.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.RavenDB.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -12,6 +12,7 @@
     using Raven.Client.Documents;
     using Raven.Client.ServerWide;
     using Raven.Client.ServerWide.Operations;
+    using Settings;
 
     public partial class PersistenceTestsConfiguration
     {
@@ -81,7 +82,7 @@
             var dbRecord = new DatabaseRecord(dbName);
             documentStore.Maintenance.Server.Send(new CreateDatabaseOperation(dbRecord));
 
-            IOpenTenantAwareRavenSessions sessionCreator = new OpenRavenSessionByDatabaseName(new DocumentStoreWrapper(documentStore));
+            IOpenTenantAwareRavenSessions sessionCreator = new OpenRavenSessionByDatabaseName(new DocumentStoreWrapper(documentStore), new SettingsHolder());
             SynchronizedStorage = new RavenDBSynchronizedStorage(sessionCreator);
             SynchronizedStorageAdapter = new RavenDBSynchronizedStorageAdapter();
 

--- a/src/NServiceBus.RavenDB.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.RavenDB.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -14,6 +14,7 @@ namespace NServiceBus.PersistenceTesting
     using Raven.Client.ServerWide;
     using Raven.Client.ServerWide.Operations;
     using Settings;
+    using Raven.Client.Documents.Session;
 
     public partial class PersistenceTestsConfiguration
     {
@@ -94,7 +95,9 @@ namespace NServiceBus.PersistenceTesting
             }
             SagaStorage = new SagaPersister(sagaPersistenceConfiguration, sessionCreator);
 
-            OutboxStorage = new OutboxPersister(documentStore.Database, sessionCreator, RavenDbOutboxStorage.DeduplicationDataTTLDefault);
+            // TODO: Is this the right setting? 
+            var useClusterWideTx = ((InMemoryDocumentSessionOperations)documentStore.OpenSession()).TransactionMode == TransactionMode.ClusterWide;
+            OutboxStorage = new OutboxPersister(documentStore.Database, sessionCreator, RavenDbOutboxStorage.DeduplicationDataTTLDefault, useClusterWideTx);
             return Task.CompletedTask;
         }
 

--- a/src/NServiceBus.RavenDB.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.RavenDB.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -22,19 +22,22 @@ namespace NServiceBus.PersistenceTesting
             var optimisticConcurrencyConfiguration = new SagaPersistenceConfiguration();
             optimisticConcurrencyConfiguration.UseOptimisticLocking();
             var pessimisticLockingConfiguration = new SagaPersistenceConfiguration();
-            var persistenceExtensionsWithClusterWideTx = new PersistenceExtensions<RavenDBPersistence>(new SettingsHolder());
-            persistenceExtensionsWithClusterWideTx.UseClusterWideTransactions();
+
+            var doNotClusterWideTx = new PersistenceExtensions<RavenDBPersistence>(new SettingsHolder());
+            var useClusterWideTx = new PersistenceExtensions<RavenDBPersistence>(new SettingsHolder());
+            useClusterWideTx.UseClusterWideTransactions();
 
             SagaVariants = new[]
             {
-                new TestVariant(optimisticConcurrencyConfiguration, new PersistenceExtensions<RavenDBPersistence>(new SettingsHolder())),
-                new TestVariant(pessimisticLockingConfiguration, new PersistenceExtensions<RavenDBPersistence>(new SettingsHolder())),
-                new TestVariant(optimisticConcurrencyConfiguration, persistenceExtensionsWithClusterWideTx),
-                new TestVariant(pessimisticLockingConfiguration, persistenceExtensionsWithClusterWideTx),
+                new TestVariant(optimisticConcurrencyConfiguration, doNotClusterWideTx),
+                new TestVariant(pessimisticLockingConfiguration, doNotClusterWideTx),
+                new TestVariant(optimisticConcurrencyConfiguration, useClusterWideTx),
+                new TestVariant(pessimisticLockingConfiguration, useClusterWideTx),
             };
             OutboxVariants = new[]
             {
-                new TestVariant(optimisticConcurrencyConfiguration)
+                new TestVariant(optimisticConcurrencyConfiguration, doNotClusterWideTx),
+                new TestVariant(optimisticConcurrencyConfiguration, useClusterWideTx)
             };
         }
 

--- a/src/NServiceBus.RavenDB.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.RavenDB.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -95,10 +95,12 @@ namespace NServiceBus.PersistenceTesting
             {
                 sagaPersistenceConfiguration.SetPessimisticLeaseLockAcquisitionTimeout(SessionTimeout.Value);
             }
-            SagaStorage = new SagaPersister(sagaPersistenceConfiguration, sessionCreator);
 
             var useClusterWideTx = settings.GetOrDefault<bool>(RavenDbStorageSession.UseClusterWideTransactions);
+
+            SagaStorage = new SagaPersister(sagaPersistenceConfiguration, sessionCreator, useClusterWideTx);
             OutboxStorage = new OutboxPersister(documentStore.Database, sessionCreator, RavenDbOutboxStorage.DeduplicationDataTTLDefault, useClusterWideTx);
+
             return Task.CompletedTask;
         }
 

--- a/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/.editorconfig
+++ b/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+
+# Justification: Test project
+dotnet_diagnostic.CA2007.severity = none

--- a/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/ConfigureEndpointRavenDBPersistence.cs
+++ b/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/ConfigureEndpointRavenDBPersistence.cs
@@ -26,9 +26,6 @@ public class ConfigureEndpointRavenDBPersistence : IConfigureEndpointTestExecuti
             .SetDefaultDocumentStore(documentStore)
             .UseClusterWideTransactions();
 
-        var sagasConfiguration = persistenceExtensions.Sagas();
-        sagasConfiguration.UsePessimisticLocking();
-
         configuration.GetSettings().Set(DefaultPersistenceExtensionsKey, persistenceExtensions);
 
         Console.WriteLine("Created '{0}' database", documentStore.Database);

--- a/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/ConfigureEndpointRavenDBPersistence.cs
+++ b/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/ConfigureEndpointRavenDBPersistence.cs
@@ -1,0 +1,141 @@
+﻿using NServiceBus;
+using NServiceBus.AcceptanceTesting.Support;
+using NServiceBus.Settings;
+using System;
+using System.Threading.Tasks;
+using NServiceBus.Configuration.AdvancedExtensibility;
+using Raven.Client.Documents;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+
+public class ConfigureEndpointRavenDBPersistence : IConfigureEndpointTestExecution
+{
+    const string DefaultDocumentStoreKey = "$.ConfigureEndpointRavenDBPersistence.DefaultDocumentStore";
+    const string DefaultPersistenceExtensionsKey = "$.ConfigureRavenDBPersistence.DefaultPersistenceExtensions";
+
+    public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings, PublisherMetadata publisherMetadata)
+    {
+        var documentStore = GetDocumentStore();
+
+        databaseName = documentStore.Database;
+
+        configuration.GetSettings().Set(DefaultDocumentStoreKey, documentStore);
+
+        var persistenceExtensions = configuration.UsePersistence<RavenDBPersistence>()
+            .DoNotCacheSubscriptions()
+            .SetDefaultDocumentStore(documentStore)
+            .UseClusterWideTransactions();
+
+        var sagasConfiguration = persistenceExtensions.Sagas();
+        sagasConfiguration.UsePessimisticLocking();
+
+        configuration.GetSettings().Set(DefaultPersistenceExtensionsKey, persistenceExtensions);
+
+        Console.WriteLine("Created '{0}' database", documentStore.Database);
+
+        return Task.FromResult(0);
+    }
+
+    public Task Cleanup()
+    {
+        return DeleteDatabase(databaseName);
+    }
+
+    public static DocumentStore GetDocumentStore()
+    {
+        var dbName = Guid.NewGuid().ToString();
+
+        var documentStore = GetInitializedDocumentStore(dbName);
+
+        CreateDatabase(documentStore, dbName);
+
+        return documentStore;
+    }
+
+    internal static DocumentStore GetInitializedDocumentStore(string defaultDatabase)
+    {
+        var urls = Environment.GetEnvironmentVariable("CommaSeparatedRavenClusterUrls") ?? "http://localhost:8080";
+
+        var documentStore = new DocumentStore
+        {
+            Urls = urls.Split(','),
+            Database = defaultDatabase
+        };
+
+        documentStore.Initialize();
+
+        return documentStore;
+    }
+
+    public static void CreateDatabase(IDocumentStore defaultStore, string dbName)
+    {
+        var dbRecord = new DatabaseRecord(dbName);
+        defaultStore.Maintenance.Server.Send(new CreateDatabaseOperation(dbRecord));
+    }
+
+    public static async Task DeleteDatabase(string dbName)
+    {
+        // Periodically the delete will throw an exception because Raven has the database locked
+        // To solve this we have a retry loop with a delay
+        var triesLeft = 3;
+
+        while (triesLeft-- > 0)
+        {
+            try
+            {
+                // We are using a new store because the global one is disposed of before cleanup
+                using (var storeForDeletion = GetInitializedDocumentStore(dbName))
+                {
+                    storeForDeletion.Maintenance.Server.Send(new DeleteDatabasesOperation(storeForDeletion.Database, hardDelete: true));
+                    break;
+                }
+            }
+            catch
+            {
+                if (triesLeft == 0)
+                {
+                    throw;
+                }
+
+                await Task.Delay(250);
+            }
+        }
+
+        Console.WriteLine("Deleted '{0}' database", dbName);
+    }
+
+    string databaseName;
+
+    public static DocumentStore GetDefaultDocumentStore(ReadOnlySettings settings)
+    {
+        return settings.Get<DocumentStore>(DefaultDocumentStoreKey);
+    }
+
+    public static PersistenceExtensions<RavenDBPersistence> GetDefaultPersistenceExtensions(ReadOnlySettings settings)
+    {
+        return settings.Get<PersistenceExtensions<RavenDBPersistence>>(DefaultPersistenceExtensionsKey);
+    }
+}
+
+public static class TestConfigurationExtensions
+{
+    public static PersistenceExtensions<RavenDBPersistence> ResetDocumentStoreSettings(this PersistenceExtensions<RavenDBPersistence> cfg, out TestDatabaseInfo dbInfo)
+    {
+        var settings = cfg.GetSettings();
+        var docStore = ConfigureEndpointRavenDBPersistence.GetDefaultDocumentStore(settings);
+
+        settings.Set("RavenDbDocumentStore", null);
+        dbInfo = new TestDatabaseInfo
+        {
+            Urls = docStore.Urls,
+            Database = docStore.Database
+        };
+        return cfg;
+    }
+}
+
+public class TestDatabaseInfo
+{
+    public string[] Urls { get; set; }
+    public string Database { get; set; }
+}

--- a/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/ConfigureEndpointRavenDBPersistence.cs
+++ b/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/ConfigureEndpointRavenDBPersistence.cs
@@ -28,6 +28,7 @@ public class ConfigureEndpointRavenDBPersistence : IConfigureEndpointTestExecuti
 
         configuration.GetSettings().Set(DefaultPersistenceExtensionsKey, persistenceExtensions);
 
+        var bla = new {Message = "Test"};
         Console.WriteLine("Created '{0}' database", documentStore.Database);
 
         return Task.FromResult(0);

--- a/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/ConfigureEndpointRavenDBPersistence.cs
+++ b/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/ConfigureEndpointRavenDBPersistence.cs
@@ -28,7 +28,6 @@ public class ConfigureEndpointRavenDBPersistence : IConfigureEndpointTestExecuti
 
         configuration.GetSettings().Set(DefaultPersistenceExtensionsKey, persistenceExtensions);
 
-        var bla = new {Message = "Test"};
         Console.WriteLine("Created '{0}' database", documentStore.Database);
 
         return Task.FromResult(0);

--- a/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests.csproj
@@ -40,9 +40,6 @@
     <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\When_using_a_sagafinder.cs">
       <Link>When_using_a_sagafinder.cs</Link>
     </Compile>
-    <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\When_using_multitenant_dbs_with_Outbox.cs">
-      <Link>When_using_multitenant_dbs_with_Outbox.cs</Link>
-    </Compile>
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests.csproj
@@ -1,0 +1,51 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <RootNamespace>NServiceBus.RavenDB.AcceptanceTests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.RavenDB\NServiceBus.RavenDB.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0-alpha.644" />
+    <PackageReference Include="NUnit" Version="3.13.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="RavenDB.Client" Version="4.2.103" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\HasUnwrappedSagaListenerRegistered.cs">
+      <Link>HasUnwrappedSagaListenerRegistered.cs</Link>
+    </Compile>
+    <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\SagaAndOutbox.cs">
+      <Link>SagaAndOutbox.cs</Link>
+    </Compile>
+    <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\When_accessing_raven_session_from_handler_with_outbox.cs">
+      <Link>When_accessing_raven_session_from_handler_with_outbox.cs</Link>
+    </Compile>
+    <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\When_accessing_raven_session_from_handler_with_saga.cs">
+      <Link>When_accessing_raven_session_from_handler_with_saga.cs</Link>
+    </Compile>
+    <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\When_detecting_a_saga_with_multiple_corr_props.cs">
+      <Link>When_detecting_a_saga_with_multiple_corr_props.cs</Link>
+    </Compile>
+    <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\When_mixing_persistence_with_other_persistence_for_sagas_and_outbox.cs">
+      <Link>When_mixing_persistence_with_other_persistence_for_sagas_and_outbox.cs</Link>
+    </Compile>
+    <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\When_raven_session_is_provided.cs">
+      <Link>When_raven_session_is_provided.cs</Link>
+    </Compile>
+    <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\When_using_a_sagafinder.cs">
+      <Link>When_using_a_sagafinder.cs</Link>
+    </Compile>
+    <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\When_using_multitenant_dbs_with_Outbox.cs">
+      <Link>When_using_multitenant_dbs_with_Outbox.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+</Project>

--- a/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests.csproj
@@ -37,9 +37,6 @@
     <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\When_mixing_persistence_with_other_persistence_for_sagas_and_outbox.cs">
       <Link>When_mixing_persistence_with_other_persistence_for_sagas_and_outbox.cs</Link>
     </Compile>
-    <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\When_raven_session_is_provided.cs">
-      <Link>When_raven_session_is_provided.cs</Link>
-    </Compile>
     <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\When_using_a_sagafinder.cs">
       <Link>When_using_a_sagafinder.cs</Link>
     </Compile>

--- a/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/TestSuiteConstraints.cs
+++ b/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/TestSuiteConstraints.cs
@@ -1,0 +1,21 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using AcceptanceTesting.Support;
+
+    public partial class TestSuiteConstraints
+    {
+        public bool SupportsDtc => false;
+
+        public bool SupportsCrossQueueTransactions => true;
+
+        public bool SupportsNativePubSub => false;
+
+        public bool SupportsDelayedDelivery => true;
+
+        public bool SupportsOutbox => true;
+
+        public IConfigureEndpointTestExecution CreateTransportConfiguration() => new ConfigureEndpointAcceptanceTestingTransport(SupportsNativePubSub, SupportsDelayedDelivery);
+
+        public IConfigureEndpointTestExecution CreatePersistenceConfiguration() => new ConfigureEndpointRavenDBPersistence();
+    }
+}

--- a/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/When_raven_session_is_provided.cs
+++ b/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/When_raven_session_is_provided.cs
@@ -1,0 +1,108 @@
+﻿namespace NServiceBus.AcceptanceTests.ApiExtension
+{
+    using System;
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using Raven.Client.Documents;
+    using Raven.Client.Documents.Session;
+
+    public class When_raven_session_is_provided : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task It_should_return_configured_session()
+        {
+            DocumentStore documentStore = null;
+            IAsyncDocumentSession session = null;
+            try
+            {
+                documentStore = ConfigureEndpointRavenDBPersistence.GetDocumentStore();
+                var options = new SessionOptions { TransactionMode = TransactionMode.ClusterWide };
+                session = documentStore.OpenAsyncSession(options);
+
+                var context =
+                    await Scenario.Define<RavenSessionTestContext>(testContext => { testContext.RavenSessionFromTest = session; })
+                        .WithEndpoint<SharedRavenSessionExtensions>(b => b.When((bus, c) =>
+                        {
+                            var sendOptions = new SendOptions();
+
+                            sendOptions.RouteToThisEndpoint();
+
+                            return bus.Send(new SharedRavenSessionExtensions.GenericMessage(), sendOptions);
+                        }))
+                        .Done(c => c.HandlerWasHit)
+                        .Run();
+
+                Assert.AreSame(session, context.RavenSessionFromHandler);
+            }
+            finally
+            {
+                if (session != null)
+                {
+                    session.Dispose();
+                    session = null;
+                }
+
+                if (documentStore != null)
+                {
+                    await ConfigureEndpointRavenDBPersistence.DeleteDatabase(documentStore.Database);
+                }
+            }
+        }
+
+        public class RavenSessionTestContext : ScenarioContext
+        {
+            public IAsyncDocumentSession RavenSessionFromTest { get; set; }
+            public IAsyncDocumentSession RavenSessionFromHandler { get; set; }
+            public bool HandlerWasHit { get; set; }
+        }
+
+        public class SharedRavenSessionExtensions : EndpointConfigurationBuilder
+        {
+            public SharedRavenSessionExtensions()
+            {
+                EndpointSetup<DefaultServer>((config, context) =>
+                {
+                    var scenarioContext = context.ScenarioContext as RavenSessionTestContext;
+                    config.UsePersistence<RavenDBPersistence>().UseSharedAsyncSession(_ => scenarioContext.RavenSessionFromTest);
+                });
+            }
+
+            public class SharedSessionSagaData : IContainSagaData
+            {
+                public Guid Id { get; set; }
+                public string Originator { get; set; }
+                public string OriginalMessageId { get; set; }
+            }
+
+            public class SharedSessionGenericSaga : Saga<SharedSessionSagaData>, IAmStartedByMessages<GenericMessage>
+            {
+                RavenSessionTestContext testContext;
+
+                public SharedSessionGenericSaga(RavenSessionTestContext testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(GenericMessage message, IMessageHandlerContext context)
+                {
+                    testContext.RavenSessionFromHandler = context.SynchronizedStorageSession.RavenSession();
+                    testContext.HandlerWasHit = true;
+                    return Task.FromResult(0);
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SharedSessionSagaData> mapper)
+                {
+                    mapper.ConfigureMapping<GenericMessage>(m => m.Id).ToSaga(s => s.Id);
+                }
+            }
+
+            [Serializable]
+            public class GenericMessage : IMessage
+            {
+                public Guid Id { get; set; }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/When_storing_saga_with_high_contention.cs
+++ b/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/When_storing_saga_with_high_contention.cs
@@ -1,0 +1,139 @@
+namespace NServiceBus.RavenDB.AcceptanceTests
+{
+    using System;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_storing_saga_with_high_contention : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_succeed_without_retries()
+        {
+            var scenario = await Scenario.Define<HighContentionScenario>()
+                .WithEndpoint<HighContentionEndpoint>(behavior =>
+                {
+                    behavior.CustomConfig(configuration => configuration.UsePersistence<RavenDBPersistence>().Sagas().UsePessimisticLocking(true));
+                    behavior.When(session => session.SendLocal(new StartSaga { SomeId = Guid.NewGuid() }));
+                })
+                .Done(s => s.SagaCompleted)
+                .Run();
+
+            Assert.IsTrue(scenario.ConcurrentMessagesSent);
+            Assert.AreEqual(0, scenario.RetryCount);
+        }
+
+        public class HighContentionScenario : ScenarioContext
+        {
+            long retryCount;
+
+            public int ConcurrentMessageCount { get; } = 20;
+
+            public bool ConcurrentMessagesSent { get; set; }
+
+            public bool SagaCompleted { get; set; }
+
+            public long RetryCount => Interlocked.Read(ref retryCount);
+
+            public void IncrementRetryCount() => Interlocked.Increment(ref retryCount);
+        }
+
+        class HighContentionEndpoint : EndpointConfigurationBuilder
+        {
+            public HighContentionEndpoint()
+            {
+                EndpointSetup<DefaultServer, HighContentionScenario>((endpoint, scenario) =>
+                {
+                    endpoint.LimitMessageProcessingConcurrencyTo(scenario.ConcurrentMessageCount);
+
+                    var recoverability = endpoint.Recoverability();
+
+                    recoverability.Immediate(immediateRetries =>
+                    {
+                        immediateRetries.OnMessageBeingRetried(m =>
+                        {
+                            scenario.IncrementRetryCount();
+                            return Task.CompletedTask;
+                        });
+
+                        immediateRetries.NumberOfRetries(scenario.ConcurrentMessageCount);
+                    });
+
+                    recoverability.Delayed(s => s.NumberOfRetries(0));
+                });
+            }
+
+            class HighContentionSaga : Saga<HighContentionSaga.HighContentionSagaData>, IAmStartedByMessages<StartSaga>, IHandleMessages<ConcurrentMessage>
+            {
+                readonly HighContentionScenario scenario;
+
+                public HighContentionSaga(HighContentionScenario scenario) => this.scenario = scenario;
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<HighContentionSagaData> mapper)
+                {
+                    mapper.ConfigureMapping<StartSaga>(message => message.SomeId).ToSaga(data => data.SomeId);
+                    mapper.ConfigureMapping<ConcurrentMessage>(message => message.SomeId).ToSaga(data => data.SomeId);
+                }
+
+                public async Task Handle(StartSaga message, IMessageHandlerContext context)
+                {
+                    await Task.WhenAll(Enumerable.Range(0, scenario.ConcurrentMessageCount).Select(_ => context.SendLocal(new ConcurrentMessage { SomeId = message.SomeId })));
+                    scenario.ConcurrentMessagesSent = true;
+                }
+
+                public class HighContentionSagaData : ContainSagaData
+                {
+                    public Guid SomeId { get; set; }
+
+                    public int HitCount { get; set; }
+                }
+
+                public async Task Handle(ConcurrentMessage message, IMessageHandlerContext context)
+                {
+                    Data.HitCount++;
+
+                    if (Data.HitCount >= scenario.ConcurrentMessageCount)
+                    {
+                        MarkAsComplete();
+                        await context.SendLocal(new SagaCompleted { SomeId = message.SomeId, HitCount = Data.HitCount });
+                    }
+                }
+            }
+
+            class DoneHandler : IHandleMessages<SagaCompleted>
+            {
+                readonly HighContentionScenario scenario;
+
+                public DoneHandler(HighContentionScenario scenario) => this.scenario = scenario;
+
+                public Task Handle(SagaCompleted message, IMessageHandlerContext context)
+                {
+                    scenario.SagaCompleted = true;
+                    return Task.CompletedTask;
+                }
+            }
+        }
+
+        public class StartSaga : IMessage
+        {
+            public Guid SomeId { get; set; }
+        }
+
+        public class ConcurrentMessage : IMessage
+        {
+            public Guid SomeId { get; set; }
+        }
+
+        public class SagaCompleted : IMessage
+        {
+            public Guid SomeId { get; set; }
+
+            public int HitCount { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/When_storing_saga_with_high_contention.cs
+++ b/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/When_storing_saga_with_high_contention.cs
@@ -18,7 +18,7 @@ namespace NServiceBus.RavenDB.AcceptanceTests
             var scenario = await Scenario.Define<HighContentionScenario>()
                 .WithEndpoint<HighContentionEndpoint>(behavior =>
                 {
-                    behavior.CustomConfig(configuration => configuration.UsePersistence<RavenDBPersistence>().Sagas().UsePessimisticLocking(true));
+                    behavior.CustomConfig(configuration => configuration.UsePersistence<RavenDBPersistence>());
                     behavior.When(session => session.SendLocal(new StartSaga { SomeId = Guid.NewGuid() }));
                 })
                 .Done(s => s.SagaCompleted)

--- a/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/When_using_multitenant_dbs_with_Outbox.cs
+++ b/src/NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests/When_using_multitenant_dbs_with_Outbox.cs
@@ -1,0 +1,192 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Configuration.AdvancedExtensibility;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+    using Raven.Client.Documents;
+    using Raven.Client.Documents.Session;
+
+    public class When_using_multitenant_dbs_with_Outbox : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_honor_SetMessageToDatabaseMappingConvention()
+        {
+            await RunTest(cfg =>
+            {
+                cfg.PersistenceExtensions.SetMessageToDatabaseMappingConvention(headers => headers.TryGetValue("RavenDatabaseName", out var dbName) ? dbName : cfg.DefaultStore.Database);
+            });
+        }
+
+        [Test]
+        public async Task Should_honor_UseSharedAsyncSession()
+        {
+            await RunTest(cfg =>
+            {
+                cfg.PersistenceExtensions.UseSharedAsyncSession(headers =>
+                {
+                    var settings = new SessionOptions
+                    {
+                        TransactionMode = TransactionMode.ClusterWide,
+                        Database = headers["RavenDatabaseName"]
+                    };
+                    return cfg.DefaultStore.OpenAsyncSession(settings);
+                });
+            });
+        }
+
+        async Task RunTest(Action<ContextDbConfig> configureMultiTenant)
+        {
+            var context = await Scenario.Define<Context>(c =>
+                {
+                    c.Db1 = "Tenant1-" + Guid.NewGuid().ToString("n").Substring(16);
+                    c.Db2 = "Tenant2-" + Guid.NewGuid().ToString("n").Substring(16);
+                })
+                .WithEndpoint<MultiTenantEndpoint>(b =>
+                {
+                    b.CustomConfig((cfg, c) =>
+                    {
+                        cfg.EnableOutbox();
+                        cfg.LimitMessageProcessingConcurrencyTo(1);
+                        cfg.Pipeline.Register(new MessageCountingBehavior(c), "Counts all messages processed");
+
+                        var settings = cfg.GetSettings();
+
+                        var defaultStore = ConfigureEndpointRavenDBPersistence.GetDefaultDocumentStore(settings);
+                        c.DefaultDb = defaultStore.Database;
+                        c.DbConfig.DefaultStore = defaultStore;
+
+                        ConfigureEndpointRavenDBPersistence.CreateDatabase(defaultStore, c.Db1);
+                        ConfigureEndpointRavenDBPersistence.CreateDatabase(defaultStore, c.Db2);
+
+                        c.DbConfig.PersistenceExtensions = ConfigureEndpointRavenDBPersistence.GetDefaultPersistenceExtensions(settings);
+                        configureMultiTenant(c.DbConfig);
+                    });
+
+                    async Task SendMessage(IMessageSession session, string messageId, string orderId, string dbName)
+                    {
+                        var msg = new TestMsg
+                        {
+                            OrderId = orderId
+                        };
+                        var opts = new SendOptions();
+                        opts.RouteToThisEndpoint();
+                        opts.SetHeader("RavenDatabaseName", dbName);
+                        opts.SetMessageId(messageId);
+                        await session.Send(msg, opts);
+                    }
+
+                    b.When(async (session, ctx) =>
+                    {
+                        var msgId1 = Guid.NewGuid().ToString();
+                        var msgId2 = Guid.NewGuid().ToString();
+
+                        await SendMessage(session, msgId1, "OrderA", ctx.Db1);
+                        await SendMessage(session, msgId1, "OrderA", ctx.Db1);
+                        await SendMessage(session, msgId2, "OrderB", ctx.Db2);
+                        await SendMessage(session, msgId2, "OrderB", ctx.Db2);
+                    });
+                })
+                .Done(c => c.MessagesObserved >= 4)
+                .Run();
+
+            await ConfigureEndpointRavenDBPersistence.DeleteDatabase(context.Db1);
+            await ConfigureEndpointRavenDBPersistence.DeleteDatabase(context.Db2);
+
+            Assert.AreEqual(4, context.MessagesObserved);
+            Assert.AreEqual(2, context.ObservedDbs.Count);
+            Assert.IsFalse(context.ObservedDbs.Any(db => db == context.DefaultDb));
+            Assert.Contains(context.Db1, context.ObservedDbs);
+            Assert.Contains(context.Db2, context.ObservedDbs);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public int MessagesReceived;
+            public string DefaultDb { get; set; }
+            public string Db1 { get; set; }
+            public string Db2 { get; set; }
+            public List<string> ObservedDbs { get; } = new List<string>();
+            public string ObservedDbsOutput => string.Join(", ", ObservedDbs);
+            public ContextDbConfig DbConfig { get; } = new ContextDbConfig();
+            public int MessagesObserved;
+        }
+
+        public class ContextDbConfig
+        {
+            public DocumentStore DefaultStore { get; set; }
+            public DocumentStore Tenant1 { get; set; }
+            public DocumentStore Tenant2 { get; set; }
+            public PersistenceExtensions<RavenDBPersistence> PersistenceExtensions { get; set; }
+        }
+
+        public class MultiTenantEndpoint : EndpointConfigurationBuilder
+        {
+            public MultiTenantEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MTSaga : Saga<MTSagaData>,
+                IAmStartedByMessages<TestMsg>
+            {
+                Context testCtx;
+
+                public MTSaga(Context testCtx)
+                {
+                    this.testCtx = testCtx;
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MTSagaData> mapper)
+                {
+                    mapper.ConfigureMapping<TestMsg>(m => m.OrderId).ToSaga(s => s.OrderId);
+                }
+
+                public Task Handle(TestMsg message, IMessageHandlerContext context)
+                {
+                    var ravenSession = context.SynchronizedStorageSession.RavenSession();
+                    if (ravenSession is InMemoryDocumentSessionOperations ravenSessionOps)
+                    {
+                        var dbName = ravenSessionOps.DatabaseName;
+                        testCtx.ObservedDbs.Add(dbName);
+                    }
+                    Interlocked.Increment(ref testCtx.MessagesReceived);
+                    return Task.FromResult(0);
+                }
+            }
+
+            public class MTSagaData : ContainSagaData
+            {
+                public virtual string OrderId { get; set; }
+            }
+        }
+
+        public class TestMsg : ICommand
+        {
+            public string OrderId { get; set; }
+        }
+
+        public class MessageCountingBehavior : IBehavior<ITransportReceiveContext, ITransportReceiveContext>
+        {
+            Context testContext;
+
+            public MessageCountingBehavior(Context testContext)
+            {
+                this.testContext = testContext;
+            }
+
+            public async Task Invoke(ITransportReceiveContext context, Func<ITransportReceiveContext, Task> next)
+            {
+                await next(context);
+
+                Interlocked.Increment(ref testContext.MessagesObserved);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB.Tests/ApprovalFiles/APIApprovals.ApproveRavenDBPersistence.approved.txt
+++ b/src/NServiceBus.RavenDB.Tests/ApprovalFiles/APIApprovals.ApproveRavenDBPersistence.approved.txt
@@ -58,6 +58,7 @@ namespace NServiceBus
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> SetDefaultDocumentStore(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.Settings.ReadOnlySettings, Raven.Client.Documents.IDocumentStore> storeCreator) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> SetDefaultDocumentStore(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<NServiceBus.Settings.ReadOnlySettings, System.IServiceProvider, Raven.Client.Documents.IDocumentStore> storeCreator) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> SetMessageToDatabaseMappingConvention(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<System.Collections.Generic.IDictionary<string, string>, string> convention) { }
+        public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseClusterWideTransactions(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> config) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> UseSharedAsyncSession(this NServiceBus.PersistenceExtensions<NServiceBus.RavenDBPersistence> cfg, System.Func<System.Collections.Generic.IDictionary<string, string>, Raven.Client.Documents.Session.IAsyncDocumentSession> getAsyncSessionFunc) { }
     }
     public static class RavenDbSubscriptionSettingsExtensions

--- a/src/NServiceBus.RavenDB.Tests/AsyncDocumentSessionExtensions.cs
+++ b/src/NServiceBus.RavenDB.Tests/AsyncDocumentSessionExtensions.cs
@@ -5,9 +5,9 @@
 
     static class AsyncDocumentSessionExtensions
     {
-        public static IAsyncDocumentSession UsingOptimisticConcurrency(this IAsyncDocumentSession session)
+        public static IAsyncDocumentSession UsingOptimisticConcurrency(this IAsyncDocumentSession session, bool useClusterWideTransactions)
         {
-            session.Advanced.UseOptimisticConcurrency = true;
+            session.Advanced.UseOptimisticConcurrency = !useClusterWideTransactions;
             return session;
         }
 

--- a/src/NServiceBus.RavenDB.Tests/Outbox/When_cleaning_outbox_messages.cs
+++ b/src/NServiceBus.RavenDB.Tests/Outbox/When_cleaning_outbox_messages.cs
@@ -25,7 +25,7 @@
         public async Task Should_delete_all_dispatched_outbox_records(bool useClusterWideTx)
         {
             // arrange
-            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default, useClusterWideTx);
+            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(useClusterWideTx), default, useClusterWideTx);
             var context = new ContextBag();
             var incomingMessageId = SimulateIncomingMessage(context).MessageId;
             var dispatchedOutboxMessage = new OutboxMessage(incomingMessageId, new TransportOperation[0]);
@@ -43,7 +43,7 @@
 
             WaitForIndexing();
 
-            var cleaner = new OutboxRecordsCleaner(store);
+            var cleaner = new OutboxRecordsCleaner(store, useClusterWideTx);
 
             // act
             await cleaner.RemoveEntriesOlderThan(DateTime.UtcNow.AddMinutes(1));

--- a/src/NServiceBus.RavenDB.Tests/Outbox/When_cleaning_outbox_messages.cs
+++ b/src/NServiceBus.RavenDB.Tests/Outbox/When_cleaning_outbox_messages.cs
@@ -20,11 +20,12 @@
             new OutboxRecordsIndex().Execute(store);
         }
 
-        [Test]
-        public async Task Should_delete_all_dispatched_outbox_records()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_delete_all_dispatched_outbox_records(bool useClusterWideTx)
         {
             // arrange
-            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default);
+            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default, useClusterWideTx);
             var context = new ContextBag();
             var incomingMessageId = SimulateIncomingMessage(context).MessageId;
             var dispatchedOutboxMessage = new OutboxMessage(incomingMessageId, new TransportOperation[0]);

--- a/src/NServiceBus.RavenDB.Tests/Outbox/When_getting_an_outbox_message.cs
+++ b/src/NServiceBus.RavenDB.Tests/Outbox/When_getting_an_outbox_message.cs
@@ -17,11 +17,12 @@ namespace NServiceBus.RavenDB.Tests.Outbox
             new OutboxRecordsIndex().Execute(store);
         }
 
-        [Test]
-        public async Task Should_get_the_message()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_get_the_message(bool useClusterWideTx)
         {
             // arrange
-            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default);
+            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default, useClusterWideTx);
             var context = new ContextBag();
             var incomingMessageId = SimulateIncomingMessage(context).MessageId;
             var outboxOperation = new OutboxRecord.OutboxOperation

--- a/src/NServiceBus.RavenDB.Tests/Outbox/When_outbox_messages_expire.cs
+++ b/src/NServiceBus.RavenDB.Tests/Outbox/When_outbox_messages_expire.cs
@@ -21,15 +21,16 @@
             new OutboxRecordsIndex().Execute(store);
         }
 
-        [Test]
-        public async Task Should_be_deleted()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_be_deleted(bool useClusterWideTx)
         {
             await store.Maintenance.SendAsync(
                 new ConfigureExpirationOperation(
                     new ExpirationConfiguration { Disabled = false, DeleteFrequencyInSec = 1, }));
 
             // arrange
-            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), TimeSpan.FromSeconds(1));
+            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), TimeSpan.FromSeconds(1), useClusterWideTx);
             var context = new ContextBag();
             var incomingMessageId = SimulateIncomingMessage(context).MessageId;
             var dispatchedOutboxMessage = new OutboxMessage(incomingMessageId, new TransportOperation[0]);

--- a/src/NServiceBus.RavenDB.Tests/Outbox/When_outbox_messages_expire.cs
+++ b/src/NServiceBus.RavenDB.Tests/Outbox/When_outbox_messages_expire.cs
@@ -30,7 +30,7 @@
                     new ExpirationConfiguration { Disabled = false, DeleteFrequencyInSec = 1, }));
 
             // arrange
-            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), TimeSpan.FromSeconds(1), useClusterWideTx);
+            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(useClusterWideTx), TimeSpan.FromSeconds(1), useClusterWideTx);
             var context = new ContextBag();
             var incomingMessageId = SimulateIncomingMessage(context).MessageId;
             var dispatchedOutboxMessage = new OutboxMessage(incomingMessageId, new TransportOperation[0]);

--- a/src/NServiceBus.RavenDB.Tests/Outbox/When_setting_as_dispatched.cs
+++ b/src/NServiceBus.RavenDB.Tests/Outbox/When_setting_as_dispatched.cs
@@ -20,11 +20,12 @@ namespace NServiceBus.RavenDB.Tests.Outbox
             new OutboxRecordsIndex().Execute(store);
         }
 
-        [Test]
-        public async Task Should_set_outbox_record_as_dispatched()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_set_outbox_record_as_dispatched(bool useClusterWideTx)
         {
             // arrange
-            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default);
+            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default, useClusterWideTx);
             var context = new ContextBag();
             var incomingMessageId = SimulateIncomingMessage(context).MessageId;
             var outboxRecordId = "Outbox/TestEndpoint/" + incomingMessageId;
@@ -59,11 +60,12 @@ namespace NServiceBus.RavenDB.Tests.Outbox
             }
         }
 
-        [Test]
-        public async Task Should_store_schema_version_in_metadata()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_store_schema_version_in_metadata(bool useClusterWideTx)
         {
             // arrange
-            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default);
+            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default, useClusterWideTx);
             var context = new ContextBag();
             var incomingMessageId = SimulateIncomingMessage(context).MessageId;
             var outboxRecordId = "Outbox/TestEndpoint/" + incomingMessageId;
@@ -88,12 +90,13 @@ namespace NServiceBus.RavenDB.Tests.Outbox
             }
         }
 
-        [Test]
-        public async Task Should_store_expiry_in_metadata_if_time_to_keep_deduplication_data_is_finite()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_store_expiry_in_metadata_if_time_to_keep_deduplication_data_is_finite(bool useClusterWideTx)
         {
             // arrange
             var timeToKeepDeduplicationData = TimeSpan.FromSeconds(60);
-            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), timeToKeepDeduplicationData);
+            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), timeToKeepDeduplicationData, useClusterWideTx);
             var context = new ContextBag();
             var incomingMessageId = SimulateIncomingMessage(context).MessageId;
             var outboxRecordId = "Outbox/TestEndpoint/" + incomingMessageId;
@@ -122,11 +125,12 @@ namespace NServiceBus.RavenDB.Tests.Outbox
             }
         }
 
-        [Test]
-        public async Task Should__not_store_expiry_in_metadata_if_time_to_keep_deduplication_data_is_infinite()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should__not_store_expiry_in_metadata_if_time_to_keep_deduplication_data_is_infinite(bool useClusterWideTx)
         {
             // arrange
-            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), Timeout.InfiniteTimeSpan);
+            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), Timeout.InfiniteTimeSpan, useClusterWideTx);
             var context = new ContextBag();
             var incomingMessageId = SimulateIncomingMessage(context).MessageId;
             var outboxRecordId = "Outbox/TestEndpoint/" + incomingMessageId;

--- a/src/NServiceBus.RavenDB.Tests/Outbox/When_setting_as_dispatched.cs
+++ b/src/NServiceBus.RavenDB.Tests/Outbox/When_setting_as_dispatched.cs
@@ -36,7 +36,6 @@ namespace NServiceBus.RavenDB.Tests.Outbox
                 TransactionMode = useClusterWideTx ? TransactionMode.ClusterWide : TransactionMode.SingleNode
             };
 
-            //TODO: if useClusterWideTx == true we need to also create the CEV for the simulated message.
             //manually store an OutboxRecord to control the OutboxRecordId format
             using (var session = store.OpenAsyncSession(sessionOptions).UsingOptimisticConcurrency(useClusterWideTx))
             {
@@ -136,15 +135,13 @@ namespace NServiceBus.RavenDB.Tests.Outbox
 
         [TestCase(true)]
         [TestCase(false)]
-        public async Task Should__not_store_expiry_in_metadata_if_time_to_keep_deduplication_data_is_infinite(bool useClusterWideTx)
+        public async Task Should_not_store_expiry_in_metadata_if_time_to_keep_deduplication_data_is_infinite(bool useClusterWideTx)
         {
             // arrange
             var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(useClusterWideTx), Timeout.InfiniteTimeSpan, useClusterWideTx);
             var context = new ContextBag();
             var incomingMessageId = SimulateIncomingMessage(context).MessageId;
             var outboxRecordId = "Outbox/TestEndpoint/" + incomingMessageId;
-
-            //TODO: if useClusterWideTx == true we need to also create the CEV for the simulated message.
 
             //manually store an OutboxRecord to control the OutboxRecordId format
             using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency(false))

--- a/src/NServiceBus.RavenDB.Tests/Outbox/When_storing_outbox_messages.cs
+++ b/src/NServiceBus.RavenDB.Tests/Outbox/When_storing_outbox_messages.cs
@@ -22,11 +22,12 @@ namespace NServiceBus.RavenDB.Tests.Outbox
             new OutboxRecordsIndex().Execute(store);
         }
 
-        [Test]
-        public async Task Should_throw_if_trying_to_insert_two_messages_with_the_same_id_in_the_same_transaction()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_throw_if_trying_to_insert_two_messages_with_the_same_id_in_the_same_transaction(bool useClusterWideTx)
         {
             // arrange
-            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default);
+            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default, useClusterWideTx);
             var context = new ContextBag();
             var incomingMessageId = SimulateIncomingMessage(context).MessageId;
             var outboxMessage1 = new OutboxMessage(incomingMessageId, new TransportOperation[0]);
@@ -47,11 +48,12 @@ namespace NServiceBus.RavenDB.Tests.Outbox
             Assert.NotNull(exception);
         }
 
-        [Test]
-        public async Task Should_throw_if_trying_to_insert_two_messages_with_the_same_id()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_throw_if_trying_to_insert_two_messages_with_the_same_id(bool useClusterWideTx)
         {
             // arrange
-            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default);
+            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default, useClusterWideTx);
             var context = new ContextBag();
             var incomingMessageId = SimulateIncomingMessage(context).MessageId;
             var outboxMessage1 = new OutboxMessage(incomingMessageId, new TransportOperation[0]);
@@ -77,11 +79,12 @@ namespace NServiceBus.RavenDB.Tests.Outbox
             Assert.NotNull(exception);
         }
 
-        [Test]
-        public async Task Should_store_outbox_record_as_not_dispatched()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_store_outbox_record_as_not_dispatched(bool useClusterWideTx)
         {
             // arrange
-            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default);
+            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default, useClusterWideTx);
             var context = new ContextBag();
             var incomingMessageId = SimulateIncomingMessage(context).MessageId;
             var outgoingMessageId = "outgoingMessageId";
@@ -107,11 +110,12 @@ namespace NServiceBus.RavenDB.Tests.Outbox
             }
         }
 
-        [Test]
-        public async Task Should_store_schema_version_in_metadata()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_store_schema_version_in_metadata(bool useClusterWideTx)
         {
             // arrange
-            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default);
+            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default, useClusterWideTx);
             var context = new ContextBag();
             var incomingMessageId = SimulateIncomingMessage(context).MessageId;
             var outboxMessage = new OutboxMessage(incomingMessageId, new[] { new TransportOperation("foo", default, default, default) });
@@ -135,11 +139,12 @@ namespace NServiceBus.RavenDB.Tests.Outbox
             }
         }
 
-        [Test]
-        public async Task Should_filter_invalid_docid_character()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_filter_invalid_docid_character(bool useClusterWideTx)
         {
             // arrange
-            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default);
+            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default, useClusterWideTx);
             var context = new ContextBag();
             var incomingMessageId = $@"{Guid.NewGuid()}\12345";
 

--- a/src/NServiceBus.RavenDB.Tests/Outbox/When_storing_outbox_messages.cs
+++ b/src/NServiceBus.RavenDB.Tests/Outbox/When_storing_outbox_messages.cs
@@ -27,7 +27,7 @@ namespace NServiceBus.RavenDB.Tests.Outbox
         public async Task Should_throw_if_trying_to_insert_two_messages_with_the_same_id_in_the_same_transaction(bool useClusterWideTx)
         {
             // arrange
-            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default, useClusterWideTx);
+            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(useClusterWideTx), default, useClusterWideTx);
             var context = new ContextBag();
             var incomingMessageId = SimulateIncomingMessage(context).MessageId;
             var outboxMessage1 = new OutboxMessage(incomingMessageId, new TransportOperation[0]);
@@ -53,7 +53,7 @@ namespace NServiceBus.RavenDB.Tests.Outbox
         public async Task Should_throw_if_trying_to_insert_two_messages_with_the_same_id(bool useClusterWideTx)
         {
             // arrange
-            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default, useClusterWideTx);
+            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(useClusterWideTx), default, useClusterWideTx);
             var context = new ContextBag();
             var incomingMessageId = SimulateIncomingMessage(context).MessageId;
             var outboxMessage1 = new OutboxMessage(incomingMessageId, new TransportOperation[0]);
@@ -84,7 +84,7 @@ namespace NServiceBus.RavenDB.Tests.Outbox
         public async Task Should_store_outbox_record_as_not_dispatched(bool useClusterWideTx)
         {
             // arrange
-            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default, useClusterWideTx);
+            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(useClusterWideTx), default, useClusterWideTx);
             var context = new ContextBag();
             var incomingMessageId = SimulateIncomingMessage(context).MessageId;
             var outgoingMessageId = "outgoingMessageId";
@@ -98,7 +98,7 @@ namespace NServiceBus.RavenDB.Tests.Outbox
             }
 
             // assert
-            using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency())
+            using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency(false))
             {
                 var outboxRecord = await session.Query<OutboxRecord>().SingleAsync(record => record.MessageId == incomingMessageId);
 
@@ -115,7 +115,7 @@ namespace NServiceBus.RavenDB.Tests.Outbox
         public async Task Should_store_schema_version_in_metadata(bool useClusterWideTx)
         {
             // arrange
-            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default, useClusterWideTx);
+            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(useClusterWideTx), default, useClusterWideTx);
             var context = new ContextBag();
             var incomingMessageId = SimulateIncomingMessage(context).MessageId;
             var outboxMessage = new OutboxMessage(incomingMessageId, new[] { new TransportOperation("foo", default, default, default) });
@@ -144,7 +144,7 @@ namespace NServiceBus.RavenDB.Tests.Outbox
         public async Task Should_filter_invalid_docid_character(bool useClusterWideTx)
         {
             // arrange
-            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(), default, useClusterWideTx);
+            var persister = new OutboxPersister("TestEndpoint", CreateTestSessionOpener(useClusterWideTx), default, useClusterWideTx);
             var context = new ContextBag();
             var incomingMessageId = $@"{Guid.NewGuid()}\12345";
 

--- a/src/NServiceBus.RavenDB.Tests/RavenDBPersistenceTestBase.cs
+++ b/src/NServiceBus.RavenDB.Tests/RavenDBPersistenceTestBase.cs
@@ -77,7 +77,7 @@
         protected IDocumentStore store;
         ReusableDB db;
 
-        internal IOpenTenantAwareRavenSessions CreateTestSessionOpener(bool useClusterWideTransactions = false)
+        internal IOpenTenantAwareRavenSessions CreateTestSessionOpener(bool useClusterWideTransactions)
         {
             return new TestOpenSessionsInPipeline(store, useClusterWideTransactions);
         }
@@ -99,7 +99,7 @@
                 {
                     TransactionMode = useClusterWideTx ? TransactionMode.ClusterWide : TransactionMode.SingleNode
                 };
-                return store.OpenAsyncSession(sessionOptions);
+                return store.OpenAsyncSession(sessionOptions).UsingOptimisticConcurrency(useClusterWideTx);
             }
         }
     }

--- a/src/NServiceBus.RavenDB.Tests/RavenDBPersistenceTestBase.cs
+++ b/src/NServiceBus.RavenDB.Tests/RavenDBPersistenceTestBase.cs
@@ -77,23 +77,29 @@
         protected IDocumentStore store;
         ReusableDB db;
 
-        internal IOpenTenantAwareRavenSessions CreateTestSessionOpener()
+        internal IOpenTenantAwareRavenSessions CreateTestSessionOpener(bool useClusterWideTransactions = false)
         {
-            return new TestOpenSessionsInPipeline(store);
+            return new TestOpenSessionsInPipeline(store, useClusterWideTransactions);
         }
 
         class TestOpenSessionsInPipeline : IOpenTenantAwareRavenSessions
         {
             IDocumentStore store;
+            bool useClusterWideTx;
 
-            public TestOpenSessionsInPipeline(IDocumentStore store)
+            public TestOpenSessionsInPipeline(IDocumentStore store, bool useClusterWideTx)
             {
                 this.store = store;
+                this.useClusterWideTx = useClusterWideTx;
             }
 
             public IAsyncDocumentSession OpenSession(IDictionary<string, string> messageHeaders)
             {
-                return store.OpenAsyncSession();
+                var sessionOptions = new SessionOptions
+                {
+                    TransactionMode = useClusterWideTx ? TransactionMode.ClusterWide : TransactionMode.SingleNode
+                };
+                return store.OpenAsyncSession(sessionOptions);
             }
         }
     }

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/Saga_with_unique_property_set_to_null.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/Saga_with_unique_property_set_to_null.cs
@@ -21,7 +21,7 @@ public class Saga_with_unique_property_set_to_null : RavenDBPersistenceTestBase
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var context))
         {
             var ravenSession = new RavenDBSynchronizedStorageSession(session, new ContextBag());
-            var persister = new SagaPersister(new SagaPersistenceConfiguration());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
 
             var exception = await Catch<ArgumentNullException>(async () =>
             {

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/Saga_with_unique_property_set_to_null.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/Saga_with_unique_property_set_to_null.cs
@@ -19,7 +19,7 @@ public class Saga_with_unique_property_set_to_null : RavenDBPersistenceTestBase
             UniqueString = null
         };
 
-        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var context))
+        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency(useClusterWideTx).InContext(out var context))
         {
             var ravenSession = new RavenDBSynchronizedStorageSession(session, new ContextBag());
             var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/Saga_with_unique_property_set_to_null.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/Saga_with_unique_property_set_to_null.cs
@@ -9,8 +9,9 @@ using NUnit.Framework;
 [TestFixture]
 public class Saga_with_unique_property_set_to_null : RavenDBPersistenceTestBase
 {
-    [Test]
-    public async Task Should_throw_a_ArgumentNullException()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Should_throw_a_ArgumentNullException(bool useClusterWideTx)
     {
         var saga1 = new SagaData
         {
@@ -21,7 +22,7 @@ public class Saga_with_unique_property_set_to_null : RavenDBPersistenceTestBase
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var context))
         {
             var ravenSession = new RavenDBSynchronizedStorageSession(session, new ContextBag());
-            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
 
             var exception = await Catch<ArgumentNullException>(async () =>
             {

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_completing_a_saga_with_unique_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_completing_a_saga_with_unique_property.cs
@@ -10,14 +10,15 @@ using Raven.Client.Documents;
 [TestFixture]
 public class When_completing_a_saga_with_unique_property : RavenDBPersistenceTestBase
 {
-    [Test]
-    public async Task Should_delete_the_saga_and_the_unique_doc()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Should_delete_the_saga_and_the_unique_doc(bool useClusterWideTx)
     {
         var sagaId = Guid.NewGuid();
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var entity = new SagaData
             {
                 Id = sagaId

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_completing_a_saga_with_unique_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_completing_a_saga_with_unique_property.cs
@@ -17,7 +17,7 @@ public class When_completing_a_saga_with_unique_property : RavenDBPersistenceTes
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
             var entity = new SagaData
             {
                 Id = sagaId

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_completing_a_saga_with_unique_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_completing_a_saga_with_unique_property.cs
@@ -6,6 +6,7 @@ using NServiceBus.RavenDB.Persistence.SagaPersister;
 using NServiceBus.RavenDB.Tests;
 using NUnit.Framework;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
 
 [TestFixture]
 public class When_completing_a_saga_with_unique_property : RavenDBPersistenceTestBase
@@ -16,7 +17,11 @@ public class When_completing_a_saga_with_unique_property : RavenDBPersistenceTes
     {
         var sagaId = Guid.NewGuid();
 
-        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
+        var sessionOptions = new SessionOptions()
+        {
+            TransactionMode = useClusterWideTx ? TransactionMode.ClusterWide : TransactionMode.SingleNode
+        };
+        using (var session = store.OpenAsyncSession(sessionOptions).UsingOptimisticConcurrency(useClusterWideTx).InContext(out var options))
         {
             var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var entity = new SagaData

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_completing_a_version3_saga.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_completing_a_version3_saga.cs
@@ -6,6 +6,7 @@ using NServiceBus.RavenDB.Persistence.SagaPersister;
 using NServiceBus.RavenDB.Tests;
 using NUnit.Framework;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
 
 [TestFixture]
 public class When_completing_a_version3_saga : RavenDBPersistenceTestBase
@@ -16,7 +17,11 @@ public class When_completing_a_version3_saga : RavenDBPersistenceTestBase
     {
         var sagaId = Guid.NewGuid();
 
-        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
+        var sessionOptions = new SessionOptions()
+        {
+            TransactionMode = useClusterWideTx ? TransactionMode.ClusterWide : TransactionMode.SingleNode
+        };
+        using (var session = store.OpenAsyncSession(sessionOptions).UsingOptimisticConcurrency(useClusterWideTx).InContext(out var options))
         {
             var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
 

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_completing_a_version3_saga.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_completing_a_version3_saga.cs
@@ -17,7 +17,7 @@ public class When_completing_a_version3_saga : RavenDBPersistenceTestBase
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
 
             var sagaEntity = new SagaData
             {

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_completing_a_version3_saga.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_completing_a_version3_saga.cs
@@ -10,14 +10,15 @@ using Raven.Client.Documents;
 [TestFixture]
 public class When_completing_a_version3_saga : RavenDBPersistenceTestBase
 {
-    [Test]
-    public async Task Should_delete_the_unique_doc_properly()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Should_delete_the_unique_doc_properly(bool useClusterWideTx)
     {
         var sagaId = Guid.NewGuid();
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
 
             var sagaEntity = new SagaData
             {

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_loading_Raven3_sagas.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_loading_Raven3_sagas.cs
@@ -39,7 +39,11 @@ class Raven3Sagas : RavenDBPersistenceTestBase
     {
         var sagaId = StoreSagaDocuments();
 
-        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency())
+        var sessionOptions = new SessionOptions()
+        {
+            TransactionMode = useClusterWideTx ? TransactionMode.ClusterWide : TransactionMode.SingleNode
+        };
+        using (var session = store.OpenAsyncSession(sessionOptions).UsingOptimisticConcurrency(useClusterWideTx))
         {
             var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var context = new ContextBag();
@@ -55,7 +59,7 @@ class Raven3Sagas : RavenDBPersistenceTestBase
             await session.SaveChangesAsync();
         }
 
-        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency())
+        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency(useClusterWideTx))
         {
             var dataDocs = await session.Advanced.LoadStartingWithAsync<SagaDataContainer>("CountingSagaDatas/");
             var uniqueDocs = await session.Advanced.LoadStartingWithAsync<SagaUniqueIdentity>("Raven3Sagas-");

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_loading_Raven3_sagas.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_loading_Raven3_sagas.cs
@@ -39,7 +39,7 @@ class Raven3Sagas : RavenDBPersistenceTestBase
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency())
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
             var context = new ContextBag();
             context.Set(session);
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, context);

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_loading_a_legacy_unique_identity.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_loading_a_legacy_unique_identity.cs
@@ -29,7 +29,7 @@ class When_loading_a_saga_with_legacy_unique_identity : RavenDBPersistenceTestBa
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
 
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, options);
 
@@ -83,7 +83,7 @@ class When_loading_a_saga_with_legacy_unique_identity : RavenDBPersistenceTestBa
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
 
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, options);
 

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_loading_a_legacy_unique_identity.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_loading_a_legacy_unique_identity.cs
@@ -20,8 +20,9 @@ class When_loading_a_saga_with_legacy_unique_identity : RavenDBPersistenceTestBa
         UnwrappedSagaListener.Register(store as DocumentStore);
     }
 
-    [Test]
-    public async Task It_should_load_successfully()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task It_should_load_successfully(bool useClusterWideTx)
     {
         var unique = Guid.NewGuid().ToString();
 
@@ -29,7 +30,7 @@ class When_loading_a_saga_with_legacy_unique_identity : RavenDBPersistenceTestBa
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
 
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, options);
 
@@ -45,8 +46,9 @@ class When_loading_a_saga_with_legacy_unique_identity : RavenDBPersistenceTestBa
         }
     }
 
-    [Test]
-    public async Task Improperly_converted_saga_can_be_fixed()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Improperly_converted_saga_can_be_fixed(bool useClusterWideTx)
     {
         var sagaId = Guid.NewGuid();
         var sagaDocId = $"SagaWithUniqueProperty/{sagaId}";
@@ -83,7 +85,7 @@ class When_loading_a_saga_with_legacy_unique_identity : RavenDBPersistenceTestBa
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
 
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, options);
 

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity.cs
@@ -10,8 +10,9 @@ using NUnit.Framework;
 [TestFixture]
 public class When_persisting_a_saga_entity : RavenDBPersistenceTestBase
 {
-    [Test]
-    public async Task Schema_version_should_be_persisted()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Schema_version_should_be_persisted(bool useClusterWideTx)
     {
         // arrange
         var entity = new SagaData
@@ -20,7 +21,7 @@ public class When_persisting_a_saga_entity : RavenDBPersistenceTestBase
             UniqueString = "SomeUniqueString",
         };
 
-        var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
+        var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var context))
         {
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, new ContextBag());

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity.cs
@@ -20,7 +20,7 @@ public class When_persisting_a_saga_entity : RavenDBPersistenceTestBase
             UniqueString = "SomeUniqueString",
         };
 
-        var persister = new SagaPersister(new SagaPersistenceConfiguration());
+        var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var context))
         {
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, new ContextBag());

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity.cs
@@ -22,7 +22,7 @@ public class When_persisting_a_saga_entity : RavenDBPersistenceTestBase
         };
 
         var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
-        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var context))
+        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency(useClusterWideTx).InContext(out var context))
         {
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, new ContextBag());
 

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_a_concrete_class_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_a_concrete_class_property.cs
@@ -22,7 +22,7 @@ public class When_persisting_a_saga_entity_with_a_concrete_class_property : Rave
             }
         };
 
-        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
+        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency(useClusterWideTx).InContext(out var options))
         {
             var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, options);

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_a_concrete_class_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_a_concrete_class_property.cs
@@ -23,7 +23,7 @@ public class When_persisting_a_saga_entity_with_a_concrete_class_property : Rave
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, options);
 
             await persister.Save(entity, this.CreateMetadata<SomeSaga>(entity), synchronizedSession, options);

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_a_concrete_class_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_a_concrete_class_property.cs
@@ -8,8 +8,9 @@ using NUnit.Framework;
 [TestFixture]
 public class When_persisting_a_saga_entity_with_a_concrete_class_property : RavenDBPersistenceTestBase
 {
-    [Test]
-    public async Task Public_setters_and_getters_of_concrete_classes_should_be_persisted()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Public_setters_and_getters_of_concrete_classes_should_be_persisted(bool useClusterWideTx)
     {
         var entity = new SagaData
         {
@@ -23,7 +24,7 @@ public class When_persisting_a_saga_entity_with_a_concrete_class_property : Rave
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, options);
 
             await persister.Save(entity, this.CreateMetadata<SomeSaga>(entity), synchronizedSession, options);

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_a_date_time_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_a_date_time_property.cs
@@ -20,7 +20,7 @@ public class When_persisting_a_saga_entity_with_a_DateTime_property : RavenDBPer
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, options);
 
             await persister.Save(entity, this.CreateMetadata<SomeSaga>(entity), synchronizedSession, options);

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_a_date_time_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_a_date_time_property.cs
@@ -8,8 +8,9 @@ using NUnit.Framework;
 [TestFixture]
 public class When_persisting_a_saga_entity_with_a_DateTime_property : RavenDBPersistenceTestBase
 {
-    [Test]
-    public async Task Datetime_property_should_be_persisted()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Datetime_property_should_be_persisted(bool useClusterWideTx)
     {
         var entity = new SagaData
         {
@@ -20,7 +21,7 @@ public class When_persisting_a_saga_entity_with_a_DateTime_property : RavenDBPer
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, options);
 
             await persister.Save(entity, this.CreateMetadata<SomeSaga>(entity), synchronizedSession, options);

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_a_date_time_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_a_date_time_property.cs
@@ -19,7 +19,7 @@ public class When_persisting_a_saga_entity_with_a_DateTime_property : RavenDBPer
             DateTimeProperty = DateTime.Parse("12/02/2010 12:00:00.01")
         };
 
-        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
+        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency(useClusterWideTx).InContext(out var options))
         {
             var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, options);

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_an_Enum_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_an_Enum_property.cs
@@ -20,7 +20,7 @@ public class When_persisting_a_saga_entity_with_an_Enum_property : RavenDBPersis
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var context))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, context);
 
             await persister.Save(entity, this.CreateMetadata<SomeSaga>(entity), synchronizedSession, context);

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_an_Enum_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_an_Enum_property.cs
@@ -19,7 +19,7 @@ public class When_persisting_a_saga_entity_with_an_Enum_property : RavenDBPersis
             Status = StatusEnum.AnotherStatus
         };
 
-        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var context))
+        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency(useClusterWideTx).InContext(out var context))
         {
             var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, context);

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_an_Enum_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_an_Enum_property.cs
@@ -8,8 +8,9 @@ using NUnit.Framework;
 [TestFixture]
 public class When_persisting_a_saga_entity_with_an_Enum_property : RavenDBPersistenceTestBase
 {
-    [Test]
-    public async Task Enums_should_be_persisted()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Enums_should_be_persisted(bool useClusterWideTx)
     {
         var entity = new SagaData
         {
@@ -20,7 +21,7 @@ public class When_persisting_a_saga_entity_with_an_Enum_property : RavenDBPersis
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var context))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, context);
 
             await persister.Save(entity, this.CreateMetadata<SomeSaga>(entity), synchronizedSession, context);

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_inherited_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_inherited_property.cs
@@ -13,7 +13,7 @@ public class When_persisting_a_saga_entity_with_inherited_property : RavenDBPers
     {
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
             var entity = new SagaData
             {
                 Id = Guid.NewGuid(),

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_inherited_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_inherited_property.cs
@@ -12,7 +12,7 @@ public class When_persisting_a_saga_entity_with_inherited_property : RavenDBPers
     [TestCase(false)]
     public async Task Inherited_property_classes_should_be_persisted(bool useClusterWideTx)
     {
-        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
+        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency(useClusterWideTx).InContext(out var options))
         {
             var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var entity = new SagaData

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_inherited_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_entity_with_inherited_property.cs
@@ -8,12 +8,13 @@ using NUnit.Framework;
 [TestFixture]
 public class When_persisting_a_saga_entity_with_inherited_property : RavenDBPersistenceTestBase
 {
-    [Test]
-    public async Task Inherited_property_classes_should_be_persisted()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Inherited_property_classes_should_be_persisted(bool useClusterWideTx)
     {
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var entity = new SagaData
             {
                 Id = Guid.NewGuid(),

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga.cs
@@ -16,7 +16,7 @@ public class When_persisting_a_saga_with_the_same_unique_property_as_a_completed
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
             var saga1 = new SagaData
             {
                 Id = saga1Id,
@@ -31,7 +31,7 @@ public class When_persisting_a_saga_with_the_same_unique_property_as_a_completed
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, options);
 
             var saga = await persister.Get<SagaData>(saga1Id, synchronizedSession, options);
@@ -41,7 +41,7 @@ public class When_persisting_a_saga_with_the_same_unique_property_as_a_completed
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, options);
 
             var saga2 = new SagaData

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga.cs
@@ -8,15 +8,16 @@ using NUnit.Framework;
 [TestFixture]
 public class When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga : RavenDBPersistenceTestBase
 {
-    [Test]
-    public async Task It_should_persist_successfully()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task It_should_persist_successfully(bool useClusterWideTx)
     {
         var saga1Id = Guid.NewGuid();
         var uniqueString = Guid.NewGuid().ToString();
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var saga1 = new SagaData
             {
                 Id = saga1Id,
@@ -31,7 +32,7 @@ public class When_persisting_a_saga_with_the_same_unique_property_as_a_completed
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, options);
 
             var saga = await persister.Get<SagaData>(saga1Id, synchronizedSession, options);
@@ -41,7 +42,7 @@ public class When_persisting_a_saga_with_the_same_unique_property_as_a_completed
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, options);
 
             var saga2 = new SagaData

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga.cs
@@ -15,7 +15,7 @@ public class When_persisting_a_saga_with_the_same_unique_property_as_a_completed
         var saga1Id = Guid.NewGuid();
         var uniqueString = Guid.NewGuid().ToString();
 
-        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
+        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency(useClusterWideTx).InContext(out var options))
         {
             var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var saga1 = new SagaData
@@ -30,7 +30,7 @@ public class When_persisting_a_saga_with_the_same_unique_property_as_a_completed
             await session.SaveChangesAsync().ConfigureAwait(false);
         }
 
-        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
+        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency(useClusterWideTx).InContext(out var options))
         {
             var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, options);
@@ -40,7 +40,7 @@ public class When_persisting_a_saga_with_the_same_unique_property_as_a_completed
             await session.SaveChangesAsync().ConfigureAwait(false);
         }
 
-        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
+        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency(useClusterWideTx).InContext(out var options))
         {
             var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, options);

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_with_the_same_unique_property_as_another_saga.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_with_the_same_unique_property_as_another_saga.cs
@@ -17,7 +17,7 @@ public class When_persisting_a_saga_with_the_same_unique_property_as_another_sag
         var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
         var uniqueString = Guid.NewGuid().ToString();
 
-        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
+        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency(useClusterWideTx).InContext(out var options))
         {
             var saga1 = new SagaData
             {
@@ -33,7 +33,7 @@ public class When_persisting_a_saga_with_the_same_unique_property_as_another_sag
 
         var exception = await Catch<ConcurrencyException>(async () =>
         {
-            using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
+            using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency(useClusterWideTx).InContext(out var options))
             {
                 var saga2 = new SagaData
                 {

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_with_the_same_unique_property_as_another_saga.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_with_the_same_unique_property_as_another_saga.cs
@@ -13,7 +13,7 @@ public class When_persisting_a_saga_with_the_same_unique_property_as_another_sag
     [Test]
     public async Task It_should_enforce_uniqueness()
     {
-        var persister = new SagaPersister(new SagaPersistenceConfiguration());
+        var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
         var uniqueString = Guid.NewGuid().ToString();
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_with_the_same_unique_property_as_another_saga.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_persisting_a_saga_with_the_same_unique_property_as_another_saga.cs
@@ -10,10 +10,11 @@ using Raven.Client.Exceptions;
 [TestFixture]
 public class When_persisting_a_saga_with_the_same_unique_property_as_another_saga : RavenDBPersistenceTestBase
 {
-    [Test]
-    public async Task It_should_enforce_uniqueness()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task It_should_enforce_uniqueness(bool useClusterWideTx)
     {
-        var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
+        var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
         var uniqueString = Guid.NewGuid().ToString();
 
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_storing_a_saga_with_a_long_namespace.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_storing_a_saga_with_a_long_namespace.cs
@@ -14,7 +14,7 @@ public class When_storing_a_saga_with_a_long_namespace : RavenDBPersistenceTestB
     {
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
             var uniqueString = Guid.NewGuid().ToString();
             var saga = new SagaWithUniquePropertyAndALongNamespace
             {

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_storing_a_saga_with_a_long_namespace.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_storing_a_saga_with_a_long_namespace.cs
@@ -13,7 +13,7 @@ public class When_storing_a_saga_with_a_long_namespace : RavenDBPersistenceTestB
     [TestCase(false)]
     public async Task Should_not_generate_a_to_long_unique_property_id(bool useClusterWideTx)
     {
-        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
+        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency(useClusterWideTx).InContext(out var options))
         {
             var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var uniqueString = Guid.NewGuid().ToString();

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_storing_a_saga_with_a_long_namespace.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_storing_a_saga_with_a_long_namespace.cs
@@ -9,12 +9,13 @@ using NUnit.Framework;
 [TestFixture]
 public class When_storing_a_saga_with_a_long_namespace : RavenDBPersistenceTestBase
 {
-    [Test]
-    public async Task Should_not_generate_a_to_long_unique_property_id()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Should_not_generate_a_to_long_unique_property_id(bool useClusterWideTx)
     {
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var uniqueString = Guid.NewGuid().ToString();
             var saga = new SagaWithUniquePropertyAndALongNamespace
             {

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_trying_to_fetch_a_non_existing_saga_by_its_unique_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_trying_to_fetch_a_non_existing_saga_by_its_unique_property.cs
@@ -9,12 +9,13 @@ using NUnit.Framework;
 [TestFixture]
 public class When_trying_to_fetch_a_non_existing_saga_by_its_unique_property : RavenDBPersistenceTestBase
 {
-    [Test]
-    public async Task It_should_return_null()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task It_should_return_null(bool useClusterWideTx)
     {
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, new ContextBag());
 
             Assert.Null(await persister.Get<SagaData>("UniqueString", Guid.NewGuid().ToString(), synchronizedSession, options));

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_trying_to_fetch_a_non_existing_saga_by_its_unique_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_trying_to_fetch_a_non_existing_saga_by_its_unique_property.cs
@@ -14,7 +14,7 @@ public class When_trying_to_fetch_a_non_existing_saga_by_its_unique_property : R
     {
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, new ContextBag());
 
             Assert.Null(await persister.Get<SagaData>("UniqueString", Guid.NewGuid().ToString(), synchronizedSession, options));

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_trying_to_fetch_a_non_existing_saga_by_its_unique_property.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_trying_to_fetch_a_non_existing_saga_by_its_unique_property.cs
@@ -13,7 +13,7 @@ public class When_trying_to_fetch_a_non_existing_saga_by_its_unique_property : R
     [TestCase(false)]
     public async Task It_should_return_null(bool useClusterWideTx)
     {
-        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
+        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency(useClusterWideTx).InContext(out var options))
         {
             var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var synchronizedSession = new RavenDBSynchronizedStorageSession(session, new ContextBag());

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_updating_a_saga_property_that_does_not_have_a_unique_attribute.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_updating_a_saga_property_that_does_not_have_a_unique_attribute.cs
@@ -12,7 +12,7 @@ public class When_updating_a_saga_property_that_does_not_have_a_unique_attribute
     [TestCase(false)]
     public async Task It_should_persist_successfully(bool useClusterWideTx)
     {
-        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
+        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency(useClusterWideTx).InContext(out var options))
         {
             var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var uniqueString = Guid.NewGuid().ToString();

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_updating_a_saga_property_that_does_not_have_a_unique_attribute.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_updating_a_saga_property_that_does_not_have_a_unique_attribute.cs
@@ -13,7 +13,7 @@ public class When_updating_a_saga_property_that_does_not_have_a_unique_attribute
     {
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
             var uniqueString = Guid.NewGuid().ToString();
 
             var saga1 = new SagaData

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_updating_a_saga_property_that_does_not_have_a_unique_attribute.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_updating_a_saga_property_that_does_not_have_a_unique_attribute.cs
@@ -8,12 +8,13 @@ using NUnit.Framework;
 [TestFixture]
 public class When_updating_a_saga_property_that_does_not_have_a_unique_attribute : RavenDBPersistenceTestBase
 {
-    [Test]
-    public async Task It_should_persist_successfully()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task It_should_persist_successfully(bool useClusterWideTx)
     {
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var uniqueString = Guid.NewGuid().ToString();
 
             var saga1 = new SagaData

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_updating_a_saga_without_unique_properties.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_updating_a_saga_without_unique_properties.cs
@@ -13,7 +13,7 @@ public class When_updating_a_saga_without_unique_properties : RavenDBPersistence
     {
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
             var uniqueString = Guid.NewGuid().ToString();
             var anotherUniqueString = Guid.NewGuid().ToString();
 

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_updating_a_saga_without_unique_properties.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_updating_a_saga_without_unique_properties.cs
@@ -8,12 +8,13 @@ using NUnit.Framework;
 [TestFixture]
 public class When_updating_a_saga_without_unique_properties : RavenDBPersistenceTestBase
 {
-    [Test]
-    public async Task It_should_persist_successfully()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task It_should_persist_successfully(bool useClusterWideTx)
     {
         using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
         {
-            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener());
+            var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var uniqueString = Guid.NewGuid().ToString();
             var anotherUniqueString = Guid.NewGuid().ToString();
 

--- a/src/NServiceBus.RavenDB.Tests/SagaPersister/When_updating_a_saga_without_unique_properties.cs
+++ b/src/NServiceBus.RavenDB.Tests/SagaPersister/When_updating_a_saga_without_unique_properties.cs
@@ -12,7 +12,7 @@ public class When_updating_a_saga_without_unique_properties : RavenDBPersistence
     [TestCase(false)]
     public async Task It_should_persist_successfully(bool useClusterWideTx)
     {
-        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency().InContext(out var options))
+        using (var session = store.OpenAsyncSession().UsingOptimisticConcurrency(useClusterWideTx).InContext(out var options))
         {
             var persister = new SagaPersister(new SagaPersistenceConfiguration(), CreateTestSessionOpener(useClusterWideTx), useClusterWideTx);
             var uniqueString = Guid.NewGuid().ToString();

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_listing_subscribers_for_a_non_existing_message_type.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_listing_subscribers_for_a_non_existing_message_type.cs
@@ -8,10 +8,11 @@ using NUnit.Framework;
 [TestFixture]
 public class When_listing_subscribers_for_a_non_existing_message_type : RavenDBPersistenceTestBase
 {
-    [Test]
-    public async Task No_subscribers_should_be_returned()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task No_subscribers_should_be_returned(bool useClusterWideTx)
     {
-        var persister = new SubscriptionPersister(store);
+        var persister = new SubscriptionPersister(store, useClusterWideTx);
         var subscriptionsForMessageType = await persister.GetSubscriberAddressesForMessage(new[] { MessageTypes.MessageA }, new ContextBag());
 
         Assert.AreEqual(0, subscriptionsForMessageType.Count());

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_listing_subscribers_for_message_types.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_listing_subscribers_for_message_types.cs
@@ -9,10 +9,11 @@ using NUnit.Framework;
 [TestFixture]
 public class When_listing_subscribers_for_message_types : RavenDBPersistenceTestBase
 {
-    [Test]
-    public async Task The_names_of_all_subscribers_should_be_returned()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task The_names_of_all_subscribers_should_be_returned(bool useClusterWideTx)
     {
-        var storage = new SubscriptionPersister(store);
+        var storage = new SubscriptionPersister(store, useClusterWideTx);
         var context = new ContextBag();
 
         await storage.Subscribe(TestClients.ClientA, MessageTypes.MessageA, context);
@@ -31,10 +32,11 @@ public class When_listing_subscribers_for_message_types : RavenDBPersistenceTest
         Assert.AreEqual(TestClients.ClientB.Endpoint, subscriptionsForMessageType.ElementAt(1).Endpoint);
     }
 
-    [Test]
-    public async Task Duplicates_should_not_be_generated_for_interface_inheritance_chains()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Duplicates_should_not_be_generated_for_interface_inheritance_chains(bool useClusterWideTx)
     {
-        var storage = new SubscriptionPersister(store);
+        var storage = new SubscriptionPersister(store, useClusterWideTx);
         var context = new ContextBag();
 
         await storage.Subscribe(TestClients.ClientA, new MessageType(typeof(ISomeInterface)), context);

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_a_subscription_message.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_a_subscription_message.cs
@@ -11,12 +11,13 @@ using Raven.Client.Documents;
 [TestFixture]
 public class When_receiving_a_subscription_message : RavenDBPersistenceTestBase
 {
-    [Test]
-    public async Task A_subscription_entry_should_be_added_to_the_database()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task A_subscription_entry_should_be_added_to_the_database(bool useClusterWideTx)
     {
         var clientEndpoint = new Subscriber("TestEndpoint", "TestEndpoint");
 
-        var storage = new SubscriptionPersister(store);
+        var storage = new SubscriptionPersister(store, useClusterWideTx);
 
         await storage.Subscribe(clientEndpoint, new MessageType("MessageType1", "1.0.0.0"), new ContextBag());
 

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_an_unsubscription_message.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_an_unsubscription_message.cs
@@ -7,10 +7,11 @@ using NUnit.Framework;
 [TestFixture]
 public class When_receiving_an_unsubscribe_message : RavenDBPersistenceTestBase
 {
-    [Test]
-    public async Task All_subscription_entries_for_specified_message_types_should_be_removed()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task All_subscription_entries_for_specified_message_types_should_be_removed(bool useClusterWideTx)
     {
-        var storage = new SubscriptionPersister(store);
+        var storage = new SubscriptionPersister(store, useClusterWideTx);
         var context = new ContextBag();
 
         await storage.Subscribe(TestClients.ClientA, MessageTypes.MessageA, context);

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_duplicate_subscription_messages.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_receiving_duplicate_subscription_messages.cs
@@ -12,10 +12,11 @@ using Raven.Client.Documents;
 [TestFixture]
 public class When_receiving_duplicate_subscription_messages : RavenDBPersistenceTestBase
 {
-    [Test]
-    public async Task Should_not_create_additional_db_rows()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Should_not_create_additional_db_rows(bool useClusterWideTx)
     {
-        var storage = new SubscriptionPersister(store)
+        var storage = new SubscriptionPersister(store, useClusterWideTx)
         {
             DisableAggressiveCaching = true
         };
@@ -36,15 +37,16 @@ public class When_receiving_duplicate_subscription_messages : RavenDBPersistence
     }
 
 
-    [Test]
-    public async Task Should_overwrite_existing_subscription()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Should_overwrite_existing_subscription(bool useClusterWideTx)
     {
         const string subscriberAddress = "testEndPoint@localhost";
         var messageType = new MessageType("SomeMessageType", "1.0.0.0");
         var subscriber_v6 = new Subscriber(subscriberAddress, "endpoint_name");
         var subscriber_v6_2 = new Subscriber(subscriberAddress, "new_endpoint_name");
 
-        var storage = new SubscriptionPersister(store)
+        var storage = new SubscriptionPersister(store, useClusterWideTx)
         {
             DisableAggressiveCaching = true
         };

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_storing_subscription.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_storing_subscription.cs
@@ -11,12 +11,13 @@ using Raven.Client.Documents;
 [TestFixture]
 public class When_storing_subscription : RavenDBPersistenceTestBase
 {
-    [Test]
-    public async Task Should_store_schema_version()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Should_store_schema_version(bool useClusterWideTx)
     {
         // arrange
         var subscriber = new Subscriber("SomeTransportAddress", "SomeEndpoint");
-        var storage = new SubscriptionPersister(store);
+        var storage = new SubscriptionPersister(store, useClusterWideTx);
 
         // act
         await storage.Subscribe(subscriber, new MessageType("MessageType1", "1.0.0.0"), new ContextBag());

--- a/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_subscriptions_versioning_is_disabled.cs
+++ b/src/NServiceBus.RavenDB.Tests/SubscriptionStorage/When_subscriptions_versioning_is_disabled.cs
@@ -10,8 +10,9 @@ using NUnit.Framework;
 [TestFixture]
 public class When_subscriptions_versioning_is_disabled : RavenDBPersistenceTestBase
 {
-    [Test]
-    public async Task Should_ignore_message_version()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Should_ignore_message_version(bool useClusterWideTx)
     {
         var subscriberAddress_v1 = "v1@localhost";
         var subscriberAddress_v2 = "v2@localhost";
@@ -20,7 +21,7 @@ public class When_subscriptions_versioning_is_disabled : RavenDBPersistenceTestB
         var subscriber_v1 = new Subscriber(subscriberAddress_v1, "some_endpoint_name");
         var subscriber_v2 = new Subscriber(subscriberAddress_v2, "another_endpoint_name");
 
-        var storage = new SubscriptionPersister(store)
+        var storage = new SubscriptionPersister(store, useClusterWideTx)
         {
             DisableAggressiveCaching = true
         };
@@ -42,8 +43,9 @@ public class When_subscriptions_versioning_is_disabled : RavenDBPersistenceTestB
         Assert.AreEqual(2, subscribers_looked_up_by_v2.Length);
     }
 
-    [Test]
-    public async Task At_unsubscribe_time_should_ignore_message_version()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task At_unsubscribe_time_should_ignore_message_version(bool useClusterWideTx)
     {
         var subscriberAddress = "subscriber@localhost";
         var endpointName = "endpoint_name";
@@ -52,7 +54,7 @@ public class When_subscriptions_versioning_is_disabled : RavenDBPersistenceTestB
         var subscriber_v1 = new Subscriber(subscriberAddress, endpointName);
         var subscriber_v2 = new Subscriber(subscriberAddress, endpointName);
 
-        var storage = new SubscriptionPersister(store)
+        var storage = new SubscriptionPersister(store, useClusterWideTx)
         {
             DisableAggressiveCaching = true
         };

--- a/src/NServiceBus.RavenDB.Tests/SynchronizedStorage/StorageSessionTests.cs
+++ b/src/NServiceBus.RavenDB.Tests/SynchronizedStorage/StorageSessionTests.cs
@@ -6,6 +6,7 @@
     using NServiceBus.Persistence.RavenDB;
     using NServiceBus.RavenDB.Tests;
     using NUnit.Framework;
+    using Raven.Client.Documents.Session;
 
     [TestFixture]
     public class StorageSessionTests : RavenDBPersistenceTestBase
@@ -16,18 +17,24 @@
             public string Value { get; set; }
         }
 
-        [Test]
-        public async Task CompleteAsync_with_savechanges_enabled_completes_transaction()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task CompleteAsync_with_savechanges_enabled_completes_transaction(bool useClusterWideTx)
         {
             var newDocument = new TestDocument { Value = "42" };
-            using (var writeDocSession = store.OpenAsyncSession().UsingOptimisticConcurrency())
+
+            var sessionOptions = new SessionOptions()
+            {
+                TransactionMode = useClusterWideTx ? TransactionMode.ClusterWide : TransactionMode.SingleNode
+            };
+            using (var writeDocSession = store.OpenAsyncSession(sessionOptions).UsingOptimisticConcurrency(useClusterWideTx))
             using (var writeSession = new RavenDBSynchronizedStorageSession(writeDocSession, new ContextBag(), true))
             {
                 await writeSession.Session.StoreAsync(newDocument);
                 await writeSession.CompleteAsync();
             }
 
-            using (var readSession = store.OpenAsyncSession().UsingOptimisticConcurrency())
+            using (var readSession = store.OpenAsyncSession().UsingOptimisticConcurrency(false))
             {
                 var storedDocument = await readSession.LoadAsync<TestDocument>(newDocument.Id);
 
@@ -36,18 +43,23 @@
             }
         }
 
-        [Test]
-        public async Task Dispose_without_complete_rolls_back()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Dispose_without_complete_rolls_back(bool useClusterWideTx)
         {
             var documentId = Guid.NewGuid().ToString();
-            using (var writeDocSession = store.OpenAsyncSession().UsingOptimisticConcurrency())
+            var sessionOptions = new SessionOptions()
+            {
+                TransactionMode = useClusterWideTx ? TransactionMode.ClusterWide : TransactionMode.SingleNode
+            };
+            using (var writeDocSession = store.OpenAsyncSession(sessionOptions).UsingOptimisticConcurrency(false))
             using (var writeSession = new RavenDBSynchronizedStorageSession(writeDocSession, new ContextBag(), true))
             {
                 await writeSession.Session.StoreAsync(new TestDocument { Value = "43" }, documentId);
                 // do not call CompleteAsync
             }
 
-            using (var readSession = store.OpenAsyncSession().UsingOptimisticConcurrency())
+            using (var readSession = store.OpenAsyncSession().UsingOptimisticConcurrency(false))
             {
                 var storedDocument = await readSession.LoadAsync<TestDocument>(documentId);
 
@@ -55,18 +67,23 @@
             }
         }
 
-        [Test]
-        public async Task CompleteAsync_without_savechanges_rolls_back()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task CompleteAsync_without_savechanges_rolls_back(bool useClusterWideTx)
         {
             var documentId = Guid.NewGuid().ToString();
-            using (var writeDocSession = store.OpenAsyncSession().UsingOptimisticConcurrency())
+            var sessionOptions = new SessionOptions()
+            {
+                TransactionMode = useClusterWideTx ? TransactionMode.ClusterWide : TransactionMode.SingleNode
+            };
+            using (var writeDocSession = store.OpenAsyncSession(sessionOptions).UsingOptimisticConcurrency(useClusterWideTx))
             using (var writeSession = new RavenDBSynchronizedStorageSession(writeDocSession, new ContextBag(), false))
             {
                 await writeSession.Session.StoreAsync(new TestDocument { Value = "43" }, documentId);
                 await writeSession.CompleteAsync();
             }
 
-            using (var readSession = store.OpenAsyncSession().UsingOptimisticConcurrency())
+            using (var readSession = store.OpenAsyncSession().UsingOptimisticConcurrency(false))
             {
                 var storedDocument = await readSession.LoadAsync<TestDocument>(documentId);
 

--- a/src/NServiceBus.RavenDB.sln
+++ b/src/NServiceBus.RavenDB.sln
@@ -15,9 +15,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\GitVersion.yml = ..\GitVersion.yml
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.RavenDB.PessimisticLock.AcceptanceTests", "NServiceBus.RavenDB.PessimisticLock.AcceptanceTests\NServiceBus.RavenDB.PessimisticLock.AcceptanceTests.csproj", "{57785D1B-193C-4B59-86C2-F8E1E6B50A0E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.RavenDB.PessimisticLock.AcceptanceTests", "NServiceBus.RavenDB.PessimisticLock.AcceptanceTests\NServiceBus.RavenDB.PessimisticLock.AcceptanceTests.csproj", "{57785D1B-193C-4B59-86C2-F8E1E6B50A0E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.RavenDB.PersistenceTests", "NServiceBus.RavenDB.PersistenceTests\NServiceBus.RavenDB.PersistenceTests.csproj", "{D4632C6A-F916-4107-9A76-EC66B3978BF8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.RavenDB.PersistenceTests", "NServiceBus.RavenDB.PersistenceTests\NServiceBus.RavenDB.PersistenceTests.csproj", "{D4632C6A-F916-4107-9A76-EC66B3978BF8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests", "NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests\NServiceBus.RavenDB.PessimisticLock.ClusterWideTx.AcceptanceTests.csproj", "{35653BBE-0E10-4801-891B-45D10BA99538}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.RavenDB.ClusterWideTx.AcceptanceTests", "NServiceBus.RavenDB.ClusterWideTx.AcceptanceTests\NServiceBus.RavenDB.ClusterWideTx.AcceptanceTests.csproj", "{5EA9987C-D4EC-499E-B6F0-BCF3DB522497}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -45,6 +49,14 @@ Global
 		{D4632C6A-F916-4107-9A76-EC66B3978BF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D4632C6A-F916-4107-9A76-EC66B3978BF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D4632C6A-F916-4107-9A76-EC66B3978BF8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{35653BBE-0E10-4801-891B-45D10BA99538}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{35653BBE-0E10-4801-891B-45D10BA99538}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35653BBE-0E10-4801-891B-45D10BA99538}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{35653BBE-0E10-4801-891B-45D10BA99538}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5EA9987C-D4EC-499E-B6F0-BCF3DB522497}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5EA9987C-D4EC-499E-B6F0-BCF3DB522497}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5EA9987C-D4EC-499E-B6F0-BCF3DB522497}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5EA9987C-D4EC-499E-B6F0-BCF3DB522497}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NServiceBus.RavenDB/Internal/DocumentStoreManager.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentStoreManager.cs
@@ -51,7 +51,7 @@
 
         static void SetDocumentStoreInternal(SettingsHolder settings, Type storageType, Func<ReadOnlySettings, IServiceProvider, IDocumentStore> storeCreator)
         {
-            var initContext = new DocumentStoreInitializer(storeCreator);
+            var initContext = new DocumentStoreInitializer(storeCreator, settings.GetOrDefault<bool>(RavenDbStorageSession.UseClusterWideTransactions));
             settings.Set(featureSettingsKeys[storageType], initContext);
         }
 
@@ -87,7 +87,7 @@
 
         static void SetDefaultStoreInternal(SettingsHolder settings, Func<ReadOnlySettings, IServiceProvider, IDocumentStore> storeCreator)
         {
-            var initContext = new DocumentStoreInitializer(storeCreator);
+            var initContext = new DocumentStoreInitializer(storeCreator, settings.GetOrDefault<bool>(RavenDbStorageSession.UseClusterWideTransactions));
             settings.Set(defaultDocStoreSettingsKey, initContext);
         }
 

--- a/src/NServiceBus.RavenDB/Outbox/OutboxPersister.cs
+++ b/src/NServiceBus.RavenDB/Outbox/OutboxPersister.cs
@@ -3,10 +3,10 @@
     using System;
     using System.Threading;
     using System.Threading.Tasks;
-    using NServiceBus.Extensibility;
-    using NServiceBus.Outbox;
+    using Extensibility;
+    using Outbox;
     using NServiceBus.RavenDB.Outbox;
-    using NServiceBus.Transport;
+    using Transport;
     using Raven.Client;
     using Raven.Client.Documents.Commands.Batches;
     using Raven.Client.Documents.Operations;
@@ -188,7 +188,7 @@ this['@metadata']['{Constants.Documents.Metadata.Expires}'] = args.Expire.At",
 
         string GetOutboxRecordId(string messageId) => $"Outbox/{endpointName}/{messageId.Replace('\\', '_')}";
 
-        const string OutboxPersisterCompareExchangePrefix = "outbox/transactions";
+        internal const string OutboxPersisterCompareExchangePrefix = "outbox/transactions";
         string endpointName;
         TransportOperation[] emptyTransportOperations = new TransportOperation[0];
         IOpenTenantAwareRavenSessions sessionCreator;

--- a/src/NServiceBus.RavenDB/Outbox/OutboxPersister.cs
+++ b/src/NServiceBus.RavenDB/Outbox/OutboxPersister.cs
@@ -137,6 +137,7 @@
                     {
                         outboxRecord.Dispatched = true;
                         outboxRecord.DispatchedAt = DateTime.UtcNow;
+                        outboxRecord.TransportOperations = new OutboxRecord.OutboxOperation[0];
                         session.StoreSchemaVersionInMetadata(outboxRecord);
 
                         var metadata = session.Advanced.GetMetadataFor(outboxRecord);

--- a/src/NServiceBus.RavenDB/Outbox/OutboxPersister.cs
+++ b/src/NServiceBus.RavenDB/Outbox/OutboxPersister.cs
@@ -38,8 +38,11 @@
                     return default;
                 }
 
-                var outboxRecordCev = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>($"{OutboxPersisterCompareExchangePrefix}/{outboxRecordId}").ConfigureAwait(false);
-                context.Set(OutboxPersisterCompareExchangeContextKey, outboxRecordCev);
+                if (useClusterWideTx)
+                {
+                    var outboxRecordCev = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>($"{OutboxPersisterCompareExchangePrefix}/{outboxRecordId}").ConfigureAwait(false);
+                    context.Set(OutboxPersisterCompareExchangeContextKey, outboxRecordCev);
+                }
             }
 
             if (result.Dispatched || result.TransportOperations.Length == 0)

--- a/src/NServiceBus.RavenDB/Outbox/OutboxPersister.cs
+++ b/src/NServiceBus.RavenDB/Outbox/OutboxPersister.cs
@@ -59,6 +59,7 @@
         {
             var session = GetSession(context);
 
+            // TODO: Do we need this? Isn't this done by the session creator anyway?
             if (useClusterWideTx == false)
             {
                 session.Advanced.UseOptimisticConcurrency = true;

--- a/src/NServiceBus.RavenDB/Outbox/OutboxRecordsCleaner.cs
+++ b/src/NServiceBus.RavenDB/Outbox/OutboxRecordsCleaner.cs
@@ -1,32 +1,55 @@
 ﻿namespace NServiceBus.Persistence.RavenDB
 {
     using System;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.RavenDB.Outbox;
     using Raven.Client.Documents;
     using Raven.Client.Documents.Operations;
     using Raven.Client.Documents.Queries;
+    using Raven.Client.Documents.Session;
 
     class OutboxRecordsCleaner
     {
-        public OutboxRecordsCleaner(IDocumentStore documentStore)
+        public OutboxRecordsCleaner(IDocumentStore documentStore, bool useClusterWideTransactions)
         {
             this.documentStore = documentStore;
+            this.useClusterWideTransactions = useClusterWideTransactions;
         }
 
         public async Task RemoveEntriesOlderThan(DateTime dateTime, CancellationToken cancellationToken = default)
         {
-            var options = new QueryOperationOptions { AllowStale = true };
+            var options = new QueryOperationOptions { AllowStale = true, RetrieveDetails = useClusterWideTransactions };
             var deleteOp = new DeleteByQueryOperation<OutboxRecord, OutboxRecordsIndex>(record => record.Dispatched && record.DispatchedAt <= dateTime, options);
 
             var operation = await documentStore.Operations.SendAsync(deleteOp, token: cancellationToken).ConfigureAwait(false);
 
             // This is going to execute multiple "status check" requests to Raven, but this does
             // not currently support CancellationToken.
-            await operation.WaitForCompletionAsync().ConfigureAwait(false);
+            if (!useClusterWideTransactions)
+            {
+                await operation.WaitForCompletionAsync().ConfigureAwait(false);
+            }
+            else
+            {
+                var result = operation.WaitForCompletion<BulkOperationResult>();
+                var compareExchangeKeysForDeletedRecords = result.Details.Select(x => $"{OutboxPersister.OutboxPersisterCompareExchangePrefix}/{((BulkOperationResult.DeleteDetails)x).Id}");
+
+                var sessionOptions = new SessionOptions { TransactionMode = TransactionMode.ClusterWide };
+                using (var session = documentStore.OpenAsyncSession(sessionOptions))
+                {
+                    foreach (var deletedCompareExchangeValueKey in compareExchangeKeysForDeletedRecords)
+                    {
+                        var cev = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>(
+                            deletedCompareExchangeValueKey).ConfigureAwait(false);
+                        session.Advanced.ClusterTransaction.DeleteCompareExchangeValue(cev);
+                    }
+                }
+            }
         }
 
         IDocumentStore documentStore;
+        bool useClusterWideTransactions;
     }
 }

--- a/src/NServiceBus.RavenDB/Outbox/OutboxRecordsCleaner.cs
+++ b/src/NServiceBus.RavenDB/Outbox/OutboxRecordsCleaner.cs
@@ -41,8 +41,7 @@
                 {
                     foreach (var deletedCompareExchangeValueKey in compareExchangeKeysForDeletedRecords)
                     {
-                        var cev = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>(
-                            deletedCompareExchangeValueKey).ConfigureAwait(false);
+                        var cev = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>(deletedCompareExchangeValueKey, cancellationToken).ConfigureAwait(false);
                         session.Advanced.ClusterTransaction.DeleteCompareExchangeValue(cev);
                     }
                 }

--- a/src/NServiceBus.RavenDB/Outbox/RavenDbOutboxStorage.cs
+++ b/src/NServiceBus.RavenDB/Outbox/RavenDbOutboxStorage.cs
@@ -22,9 +22,10 @@
                 .CreateIndexOnInitialization(new OutboxRecordsIndex());
 
             var timeToKeepDeduplicationData = context.Settings.GetOrDefault<TimeSpan?>(TimeToKeepDeduplicationData) ?? DeduplicationDataTTLDefault;
+            var useClusterWideTx = context.Settings.GetOrDefault<bool>(RavenDbStorageSession.UseClusterWideTransactions);
 
             context.Services.AddTransient<IOutboxStorage>(
-                sp => new OutboxPersister(context.Settings.EndpointName(), sp.GetRequiredService<IOpenTenantAwareRavenSessions>(), timeToKeepDeduplicationData));
+                sp => new OutboxPersister(context.Settings.EndpointName(), sp.GetRequiredService<IOpenTenantAwareRavenSessions>(), timeToKeepDeduplicationData, useClusterWideTx));
 
             var frequencyToRunDeduplicationDataCleanup = context.Settings.GetOrDefault<TimeSpan?>(FrequencyToRunDeduplicationDataCleanup) ?? TimeSpan.FromMinutes(1);
 

--- a/src/NServiceBus.RavenDB/Outbox/RavenDbOutboxStorage.cs
+++ b/src/NServiceBus.RavenDB/Outbox/RavenDbOutboxStorage.cs
@@ -32,7 +32,7 @@
             context.RegisterStartupTask(builder =>
             {
                 var store = DocumentStoreManager.GetDocumentStore<StorageType.Outbox>(context.Settings, builder);
-                return new OutboxCleaner(new OutboxRecordsCleaner(store), frequencyToRunDeduplicationDataCleanup, timeToKeepDeduplicationData);
+                return new OutboxCleaner(new OutboxRecordsCleaner(store, useClusterWideTx), frequencyToRunDeduplicationDataCleanup, timeToKeepDeduplicationData);
             });
 
             context.Settings.AddStartupDiagnosticsSection(

--- a/src/NServiceBus.RavenDB/RavenDbSettingsExtensions.cs
+++ b/src/NServiceBus.RavenDB/RavenDbSettingsExtensions.cs
@@ -83,5 +83,15 @@
         {
             return cfg.GetSettings().GetOrCreate<SagaPersistenceConfiguration>();
         }
+
+        /// <summary>
+        /// Configures the persistence to make use of cluster wide transactions.
+        /// </summary>
+        public static PersistenceExtensions<RavenDBPersistence> UseClusterWideTransactions(
+            this PersistenceExtensions<RavenDBPersistence> config)
+        {
+            config.GetSettings().Set(RavenDbStorageSession.UseClusterWideTransactions, true);
+            return config;
+        }
     }
 }

--- a/src/NServiceBus.RavenDB/SagaPersister/SagaPersister.cs
+++ b/src/NServiceBus.RavenDB/SagaPersister/SagaPersister.cs
@@ -300,9 +300,9 @@ namespace NServiceBus.Persistence.RavenDB
         const string SagaContainerContextKeyPrefix = "SagaDataContainer:";
         static Random random = new Random();
 
-        internal const string SagaIdCompareExchange = "NServiceBus.RavenDB.ClusterWideTx.SagaID";
-        internal const string SagaUniqueDocIdCompareExchange = "NServiceBus.RavenDB.ClusterWideTx.SagaUniqueDocID";
-        internal const string SagaPersisterCompareExchangePrefix = "SagaCevPrefix";
+        const string SagaIdCompareExchange = "NServiceBus.RavenDB.ClusterWideTx.SagaID";
+        const string SagaUniqueDocIdCompareExchange = "NServiceBus.RavenDB.ClusterWideTx.SagaUniqueDocID";
+        const string SagaPersisterCompareExchangePrefix = "sagas";
         IOpenTenantAwareRavenSessions openTenantAwareRavenSessions;
         TimeSpan leaseLockTime;
         bool enablePessimisticLocking;

--- a/src/NServiceBus.RavenDB/SagaPersister/SagaPersister.cs
+++ b/src/NServiceBus.RavenDB/SagaPersister/SagaPersister.cs
@@ -131,7 +131,10 @@ namespace NServiceBus.Persistence.RavenDB
             if (useClusterWideTx)
             {
                 // if we can't find the compare exchange value, we're in an upgrade scenario
-
+                // We could create missing CEV here, however:
+                //  - It'd be a side effect for a read operation
+                //  - we would need to do that out of band to store them in storage because the current session doesn't get flushed till the end
+                //  - we can handle this during update/save
                 var sagaIdCev = await documentSession.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>($"{SagaPersisterCompareExchangePrefix}/{sagaWrapper.Id}").ConfigureAwait(false);
                 var sagaUniqueDocIdCev = await documentSession.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>($"{SagaPersisterCompareExchangePrefix}/{sagaWrapper.IdentityDocId}").ConfigureAwait(false);
                 context.Set(SagaIdCompareExchange, sagaIdCev);

--- a/src/NServiceBus.RavenDB/SagaPersister/SagaPersister.cs
+++ b/src/NServiceBus.RavenDB/SagaPersister/SagaPersister.cs
@@ -90,6 +90,10 @@ namespace NServiceBus.Persistence.RavenDB
                     documentSession.Advanced.ClusterTransaction.CreateCompareExchangeValue($"{SagaPersisterCompareExchangePrefix}/{container.Id}", container.Id);
                     documentSession.Advanced.ClusterTransaction.CreateCompareExchangeValue($"{SagaPersisterCompareExchangePrefix}/{container.IdentityDocId}", container.Id);
                 }
+                else if (sagaIdCev == null || sagaUniqueDocIdCev == null)
+                {
+                    throw new Exception($"One of the required compare exchange values for the saga identified by '{sagaData.Id}' is missing. Please contact support with this exception message.");
+                }
                 else
                 {
                     documentSession.Advanced.ClusterTransaction.UpdateCompareExchangeValue(new CompareExchangeValue<string>(sagaIdCev.Key, sagaIdCev.Index, sagaIdCev.Value));

--- a/src/NServiceBus.RavenDB/SagaPersister/SagaPersister.cs
+++ b/src/NServiceBus.RavenDB/SagaPersister/SagaPersister.cs
@@ -44,7 +44,6 @@ namespace NServiceBus.Persistence.RavenDB
                 Data = sagaData,
                 IdentityDocId = SagaUniqueIdentity.FormatId(sagaData.GetType(), correlationProperty.Name, correlationProperty.Value),
             };
-            documentSession.StoreSchemaVersionInMetadata(container);
 
             var sagaUniqueIdentity = new SagaUniqueIdentity
             {
@@ -53,7 +52,6 @@ namespace NServiceBus.Persistence.RavenDB
                 UniqueValue = correlationProperty.Value,
                 SagaDocId = container.Id
             };
-            documentSession.StoreSchemaVersionInMetadata(sagaUniqueIdentity);
 
             if (useClusterWideTx)
             {
@@ -71,6 +69,9 @@ namespace NServiceBus.Persistence.RavenDB
                 await documentSession.StoreAsync(container, string.Empty, container.Id).ConfigureAwait(false);
                 await documentSession.StoreAsync(sagaUniqueIdentity, string.Empty, id: container.IdentityDocId).ConfigureAwait(false);
             }
+
+            documentSession.StoreSchemaVersionInMetadata(container);
+            documentSession.StoreSchemaVersionInMetadata(sagaUniqueIdentity);
         }
 
         public Task Update(IContainSagaData sagaData, SynchronizedStorageSession session, ContextBag context)

--- a/src/NServiceBus.RavenDB/SagaPersister/SagaPersister.cs
+++ b/src/NServiceBus.RavenDB/SagaPersister/SagaPersister.cs
@@ -122,7 +122,7 @@ namespace NServiceBus.Persistence.RavenDB
 
             if (useClusterWideTx)
             {
-                // TODO: if we can't find the compare exchange value, we're in an upgrade scenario
+                // if we can't find the compare exchange value, we're in an upgrade scenario
 
                 var sagaIdCev = await documentSession.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>($"{SagaPersisterCompareExchangePrefix}/{sagaWrapper.Id}").ConfigureAwait(false);
                 var sagaUniqueDocIdCev = await documentSession.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>($"{SagaPersisterCompareExchangePrefix}/{sagaWrapper.IdentityDocId}").ConfigureAwait(false);

--- a/src/NServiceBus.RavenDB/SessionManagement/OpenRavenSessionByCustomDelegate.cs
+++ b/src/NServiceBus.RavenDB/SessionManagement/OpenRavenSessionByCustomDelegate.cs
@@ -27,6 +27,7 @@
             else
             {
                 // Optimistic concurrency is not compatible with cluster wide concurrency
+                // TODO: log if we change the value
                 session.Advanced.UseOptimisticConcurrency = true;
             }
 

--- a/src/NServiceBus.RavenDB/SessionManagement/OpenRavenSessionByDatabaseName.cs
+++ b/src/NServiceBus.RavenDB/SessionManagement/OpenRavenSessionByDatabaseName.cs
@@ -3,28 +3,45 @@
     using System;
     using System.Collections.Generic;
     using Raven.Client.Documents.Session;
+    using Settings;
 
     class OpenRavenSessionByDatabaseName : IOpenTenantAwareRavenSessions
     {
-        public OpenRavenSessionByDatabaseName(IDocumentStoreWrapper documentStoreWrapper, Func<IDictionary<string, string>, string> getDatabaseName = null)
+        public OpenRavenSessionByDatabaseName(IDocumentStoreWrapper documentStoreWrapper, ReadOnlySettings settings, Func<IDictionary<string, string>, string> getDatabaseName = null)
         {
             this.documentStoreWrapper = documentStoreWrapper;
+            this.settings = settings;
             this.getDatabaseName = getDatabaseName ?? (context => string.Empty);
         }
 
         public IAsyncDocumentSession OpenSession(IDictionary<string, string> messageHeaders)
         {
             var databaseName = getDatabaseName(messageHeaders);
-            var documentSession = string.IsNullOrEmpty(databaseName)
-                ? documentStoreWrapper.DocumentStore.OpenAsyncSession()
-                : documentStoreWrapper.DocumentStore.OpenAsyncSession(databaseName);
+            IAsyncDocumentSession documentSession;
+            var useClusterWideTx = settings.GetOrDefault<bool>(RavenDbStorageSession.UseClusterWideTransactions);
 
-            documentSession.Advanced.UseOptimisticConcurrency = true;
+            var options = new SessionOptions();
+            if (useClusterWideTx)
+            {
+                options.TransactionMode = TransactionMode.ClusterWide;
+            }
+            if (string.IsNullOrEmpty(databaseName))
+            {
+                documentSession = documentStoreWrapper.DocumentStore.OpenAsyncSession(options);
+            }
+            else
+            {
+                options.Database = databaseName;
+                documentSession = documentStoreWrapper.DocumentStore.OpenAsyncSession(options);
+            }
+
+            documentSession.Advanced.UseOptimisticConcurrency = !useClusterWideTx;
 
             return documentSession;
         }
 
         IDocumentStoreWrapper documentStoreWrapper;
+        readonly ReadOnlySettings settings;
         Func<IDictionary<string, string>, string> getDatabaseName;
     }
 }

--- a/src/NServiceBus.RavenDB/SessionManagement/OpenRavenSessionByDatabaseName.cs
+++ b/src/NServiceBus.RavenDB/SessionManagement/OpenRavenSessionByDatabaseName.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Persistence.RavenDB
+namespace NServiceBus.Persistence.RavenDB
 {
     using System;
     using System.Collections.Generic;

--- a/src/NServiceBus.RavenDB/SessionManagement/RavenDbStorageSession.cs
+++ b/src/NServiceBus.RavenDB/SessionManagement/RavenDbStorageSession.cs
@@ -15,10 +15,10 @@
 
             // Check to see if the user provided us with a shared session to work with before we go and create our own to inject into the pipeline
             var getAsyncSessionFunc = context.Settings.GetOrDefault<Func<IDictionary<string, string>, IAsyncDocumentSession>>(SharedAsyncSession);
-
+            var useClusterWideTx = context.Settings.GetOrDefault<bool>(UseClusterWideTransactions);
             if (getAsyncSessionFunc != null)
             {
-                IOpenTenantAwareRavenSessions sessionCreator = new OpenRavenSessionByCustomDelegate(getAsyncSessionFunc);
+                IOpenTenantAwareRavenSessions sessionCreator = new OpenRavenSessionByCustomDelegate(getAsyncSessionFunc, useClusterWideTx);
                 context.Services.AddSingleton(sessionCreator);
 
                 context.Settings.AddStartupDiagnosticsSection(

--- a/src/NServiceBus.RavenDB/SessionManagement/RavenDbStorageSession.cs
+++ b/src/NServiceBus.RavenDB/SessionManagement/RavenDbStorageSession.cs
@@ -35,7 +35,7 @@
                     var store = DocumentStoreManager.GetDocumentStore<StorageType.Sagas>(context.Settings, sp);
                     var storeWrapper = new DocumentStoreWrapper(store);
                     var dbNameConvention = context.Settings.GetOrDefault<Func<IDictionary<string, string>, string>>(MessageToDatabaseMappingConvention);
-                    return new OpenRavenSessionByDatabaseName(storeWrapper, dbNameConvention);
+                    return new OpenRavenSessionByDatabaseName(storeWrapper, context.Settings, dbNameConvention);
                 });
 
                 context.Settings.AddStartupDiagnosticsSection(
@@ -51,5 +51,6 @@
         internal const string SharedAsyncSession = "RavenDbSharedAsyncSession";
         internal const string MessageToDatabaseMappingConvention = "RavenDB.SetMessageToDatabaseMappingConvention";
         const string StartupDiagnosticsSectionName = "NServiceBus.Persistence.RavenDB.StorageSession";
+        internal const string UseClusterWideTransactions = "NServiceBus.Persistence.RavenDB.UseClusterWideTransactions";
     }
 }

--- a/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionStorage.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/RavenDbSubscriptionStorage.cs
@@ -15,6 +15,7 @@
         {
             var doNotCacheSubscriptions = context.Settings.GetOrDefault<bool>(DoNotCacheSubscriptions);
             var cacheSubscriptionsFor = context.Settings.GetOrDefault<TimeSpan?>(CacheSubscriptionsFor) ?? TimeSpan.FromMinutes(1);
+            var useClusterWideTx = context.Settings.GetOrDefault<bool>(RavenDbStorageSession.UseClusterWideTransactions);
 
             context.Settings.AddStartupDiagnosticsSection(
                 "NServiceBus.Persistence.RavenDB.Subscriptions",
@@ -28,7 +29,7 @@
             {
                 var store = DocumentStoreManager.GetDocumentStore<StorageType.Subscriptions>(context.Settings, builder);
 
-                return new SubscriptionPersister(store)
+                return new SubscriptionPersister(store, useClusterWideTx)
                 {
                     DisableAggressiveCaching = doNotCacheSubscriptions,
                     AggressiveCacheDuration = cacheSubscriptionsFor,

--- a/src/NServiceBus.RavenDB/Subscriptions/SubscriptionPersister.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/SubscriptionPersister.cs
@@ -155,6 +155,8 @@ namespace NServiceBus.Persistence.RavenDB
 
                         await session.SaveChangesAsync().ConfigureAwait(false);
                     }
+
+                    return;
                 }
                 catch (ConcurrencyException)
                 {

--- a/src/NServiceBus.RavenDB/Subscriptions/SubscriptionPersister.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/SubscriptionPersister.cs
@@ -165,6 +165,7 @@ namespace NServiceBus.Persistence.RavenDB
 
         IAsyncDocumentSession OpenAsyncSession()
         {
+            // TODO: we need to make use of a cluster wide transaction here if they are enabled, optimistic concurrency might result in dataloss if two subscriptions are handled on two different nodes
             var session = documentStore.OpenAsyncSession();
             session.Advanced.UseOptimisticConcurrency = true;
             return session;

--- a/src/NServiceBus.RavenDB/Subscriptions/SubscriptionPersister.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/SubscriptionPersister.cs
@@ -219,7 +219,7 @@ namespace NServiceBus.Persistence.RavenDB
 
         IDocumentStore documentStore;
         bool useClusterWideTx;
-        const string SubscriptionPersisterCompareExchangePrefix = "SubscriptionCevPrefix";
+        const string SubscriptionPersisterCompareExchangePrefix = "subscriptions";
 
         sealed class EmptyDisposable : IDisposable
         {


### PR DESCRIPTION
Fix #436 

## Description

To guarantee saga data and outbox consistency in a RavenDB cluster the NServiceBus.RavenDB persistence needs to make use of cluster-wide transactions. Using cluster-wide transactions requires the following setup:

- Each RavenDB session that needs to participate in a cluster-wide transaction needs to be created with `SesssionOptions.TransactionMode` set to `TransactionMode.ClusterWide`
- `session.Advanced.UseOptimisitcConcurrency` must be set to `false`
- the session needs to use compare exchange values alongside regular documents to guarantee consistency across the cluster (more information on this [blog post](https://ayende.com/blog/183426-C/ravendb-4-1-features-cluster-wide-acid-transactions))

### Upgrade scenarios

The implementation **supports** upgrading an existing system to use cluster-wide transactions even if saga data were created not using cluster-wide transactions support. Required compare exchange values are created on the fly as needed whenever touching a saga data instance that was created without an accompanying compare exchange value.

The implementation **DOES NOT support** upgrading an existing system to use cluster-wide transactions when it comes to outbox records. The outbox is designed to be idempotent and we couldn't find a valid scenario in which a so-called upgrade was needed. Existing systems using the outbox can be safely upgraded to use cluster-wide transactions even if existing outbox records were not created using cluster-wide transactions.

The implementation and the mentioned saga data upgrade scenario make it impossible to upgrade an endpoint with no downtime. I.e. if an endpoint is scaled out into multiple instances it's impossible to upgrade them, to use cluster-wide transactions, one by one. All endpoint instances must be shut down and upgraded at the same time.

### Implementation

Cluster-wide transactions must be enabled when configuring the RavenDB persistence, e.g. using:

```
var persistenceConfig = endpoitConfig.UsePersistence<RavenDBPersistence>();
persistenceConfig.UseClusterWideTransactions();
```

From now on all created sessions must be configured to use cluster-wide transactions and to not use optimistic concurrency. There is no way, we evaluated but deemed that too risky, to use cluster-wide transactions on a case-by-case scenario. E.g. for one message use cluster-wide transactions and for a different one not use them.

#### Outbox

The outbox flow is more or less the following:

- A message enters the pipeline
- NServiceBus asks the outbox persister (`Get` operation) to retrieve an outbox record for the incoming message
- If none is found the assumption is that it's the first time we see the message
- the rest pipeline is invoked as expected
- NServiceBus asks the outbox persister to persist (`Store` operation) an outbox record for the processed message
- Once the message processing is completed, NServiceBus asks the outbox persister to set the record as dispatched (`SetAsDispatched` operation)

> _The most important assumption we made is that the NServiceBus Outbox implementation never tries to `Store` an existing outbox record, but only new records._

When Core calls `OutboxPersister.Get(messageId, ContextBag)` we try to retrieve an existing `OutboxRecord` for the given message, if none is found we return null. If one is found we also try to load the related compare exchange value; in case one exist we store that in the `ContextBag`. If none exist we are in an upgrade scenario, we decided that it doesn't make sense to create a compare exchange value at this time for two reasons:

1. creating documents during a read operation violates the expectation of the read operation to have no side effects
2. the only use case for this is when we're processing a duplicate message, in which case NServiceBus will never call `Store`

When the message processing pipeline completes and it's not processing a duplicate message, NServiceBus calls `OutboxPersister.Store(OutboxMessage, OutboxTransaction, ContextBag)`. If the persister is configured to use cluster-wide transactions, a compare exchange value is created for the store operation. The intention is to prevent different endpoint instances that are processing duplicate messages in parallel to all succeed. The cluster-wide transaction will reject any attempt, but one, to create the compare exchange value. All the failing instances will retry the message, at which point the `OutboxRecord` will be safely stored in the cluster and NServiceBus will discard the message as a duplicate (to be precise will invoke `SetAsDispatched`).

Once the outbox record is safely stored and the processing pipeline is finished, NServiceBus invokes `OutboxPersister.SetAsDispatched(messageId, ContextBag)`. The decision at this stage is to not use cluster-wide transactions at all. The `SetAsDispatched` operation is idempotent. If multiple endpoint instances are concurrently setting a message as dispatched we're OK with the last one overwriting all the others.

#### Sagas

The saga persistence support for cluster-wide transactions comes in two flavors:

1. No need to upgrade, i.e. the saga is created using cluster-wide transactions
2. Saga must be upgraded to use cluster-wide transactions because it was created without using cluster-wide transactions

For sagas to work with cluster-wide transactions we need two compare exchange values for each saga data instance stored in the storage. Sagas can be retrieved either by using the saga ID (e.g. when dispatching a timeout to a saga) or by a combination of correlation property name and correlation property value (e.g. when using regular messages). When in an upgrade scenario we have no idea if the saga will be invoked by a timeout first or by a regular message. That means that we have no way to predict which type of lookup will be performed by NServiceBus.

In an upgrade scenario, the storage will only contain the `saga container` documents. If the thing that touches the saga first is a timeout the saga lookup will be by saga id; otherwise, it'll be by correlation property name + value.
In an upgrade scenario, there are no existing compare exchange values. At saga load time the persister will look for the compare exchange values and if found it stores them into the `ContextBag`.
When NServiceBus Core invokes `Save` or `Update`, the persister determines the upgrade scenario by looking at the compare exchange values in the `ContextBag`, if they are not there it's an upgrade scenario, and compare exchange values are created. If there are present compare exchange values are updated. In both cases, the cluster-wide transactions check works as a semaphore preventing the creation or the update of new or existing saga instances.

Most of the complexity comes with saga completion scenarios. In non-upgrade scenarios it's straightforward, the persister deleted the compare exchange values, and the delete operation (like for the update or creation ones) is the gatekeeper
: only one will succeed if concurrent delete operations try to delete the same compare exchange value.

Upgrade scenarios, though, are trickier. In an upgrade scenario what could happen is that the saga completion is invoked for sagas for which there are no compare exchange values, they were created without using cluster-wide transactions. The only way for the persister to guarantee consistency in this latter scenario is to create so-called out-of-band compare exchange values. When NServiceBus Core calls `Complete` the persister checks for the presence of the compare exchange values in the `ContextBag`; if they are not available it's an upgrade scenario; the persister then:

1. creates an out-of-band `IAsyncDocumentSession` (it cannot use the existing one as it needs to commit this out-of-band session without affecting any pending user transaction/session)
2. creates on the fly the required compare exchange values like if the saga instances was just created
3. Commits the out-of-band session to safely store the required compare exchange values
4. Goes back to using the regular session that comes from the pipeline and tries to delete the just created compare exchange values as it would have done in a non-upgrade scenario.

## Ghost reads

_implementation to be added_

The above describes what needs to be done to perform a consistent write operation in the context of a cluster. That's not the whole story, though 😁. Given that getting a document and getting the related compare exchange value are two different session operations there is the possibility (and in high throughput scenarios it's very likely) that the compare exchange value and the document are out of sync. This can happen if in between the two read operations a write operation updates both, in this case, the one read first will be stale.

To avoid the ghost read problems the following approach must be implemented when reading saga data and outbox records (and subsequently must be implemented by customers):

```
var aDocument = session.LoadAsync<MyDocument>( docId );
var aDocumentMetadata = session.GetDocumentMetadata( aDocument );
var aDocumentCompareExchange = session.Advanced.ClusterTransactions.GetCompareExchangeAsync<CevSyncDocument>(cevPrefix + docId);

if(aDocumentCompareExchange == null && aDocument != nulll)
{
   //this is an upgrade scenario, the document was created without cluster-wide transactions. Now what?
}

if(aDocumentMetadata["sync-guid"] != aDocumentCompareExchange.SyncGuid)
{
   //this is a ghost read, throw or retry
}
```

And before writing back to the cluster the `synch-guid`s must be updated to guarantee the next read operation can be consistent too.

```
var newSyncGuid = Guid.NewGuid().ToString();
aDocumentMetadata["sync-guid"] = newSyncGuid;
aDocumentCompareExchange.SyncGuid = newSyncGuid;
```
The following repository https://github.com/mauroservienti/RavenClusterWideTxSpikes/ contains a full sample demonstrating how to implement it.