### PR TITLE
RavenDBSynchronizedStorage doesn't make RavenDB session available for behaviors

### DIFF
--- a/src/NServiceBus.RavenDB.AcceptanceTests/When_injecting_the_raven_session.cs
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/When_injecting_the_raven_session.cs
@@ -1,0 +1,140 @@
+﻿namespace NServiceBus.AcceptanceTests.ApiExtension
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using Raven.Client.Documents;
+    using Raven.Client.Documents.Session;
+
+    public class When_injecting_the_raven_session : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task It_should_return_configured_session()
+        {
+            DocumentStore documentStore = null;
+            IAsyncDocumentSession session = null;
+            try
+            {
+                documentStore = ConfigureEndpointRavenDBPersistence.GetDocumentStore();
+                session = documentStore.OpenAsyncSession();
+
+                RavenSessionTestContext context =
+                    await Scenario.Define<RavenSessionTestContext>(testContext =>
+                        {
+                            testContext.RavenSessionFromTest = session;
+                        })
+                        .WithEndpoint<SharedRavenSessionExtensions>(b =>
+                            b.CustomConfig(config =>
+                                {
+                                    config.UsePersistence<RavenDBPersistence>().UseSharedAsyncSession(_ => session);
+                                })
+                                .When((bus, c) =>
+                                {
+                                    var sendOptions = new SendOptions();
+
+                                    sendOptions.RouteToThisEndpoint();
+
+                                    return bus.Send(new SharedRavenSessionExtensions.GenericMessage(), sendOptions);
+                                }))
+                        .Done(c => c.HandlerWasHit)
+                        .Run();
+
+                Assert.AreSame(session, context.RavenSessionFromHandler);
+            }
+            finally
+            {
+                if (session != null)
+                {
+                    session.Dispose();
+                    session = null;
+                }
+
+                if (documentStore != null)
+                {
+                    await ConfigureEndpointRavenDBPersistence.DeleteDatabase(documentStore.Database);
+                }
+            }
+        }
+
+        [Test]
+        public async Task It_should_return_a_new_one_when_none_was_configured()
+        {
+            DocumentStore documentStore = null;
+            try
+            {
+                documentStore = ConfigureEndpointRavenDBPersistence.GetDocumentStore();
+
+                RavenSessionTestContext context =
+                    await Scenario.Define<RavenSessionTestContext>(testContext => { })
+                        .WithEndpoint<SharedRavenSessionExtensions>(b => b.When((bus, c) =>
+                        {
+                            var sendOptions = new SendOptions();
+
+                            sendOptions.RouteToThisEndpoint();
+
+                            return bus.Send(new SharedRavenSessionExtensions.GenericMessage(), sendOptions);
+                        }))
+                        .Done(c => c.HandlerWasHit)
+                        .Run();
+
+                Assert.IsNotNull(context.RavenSessionFromHandler);
+            }
+            finally
+            {
+                if (documentStore != null)
+                {
+                    await ConfigureEndpointRavenDBPersistence.DeleteDatabase(documentStore.Database);
+                }
+            }
+        }
+
+        public class RavenSessionTestContext : ScenarioContext
+        {
+            public IAsyncDocumentSession RavenSessionFromTest { get; set; }
+            public IAsyncDocumentSession RavenSessionFromHandler { get; set; }
+            public bool HandlerWasHit { get; set; }
+        }
+
+        public class SharedRavenSessionExtensions : EndpointConfigurationBuilder
+        {
+            public SharedRavenSessionExtensions() => EndpointSetup<DefaultServer>();
+
+            public class SharedSessionSagaData : IContainSagaData
+            {
+                public Guid Id { get; set; }
+                public string Originator { get; set; }
+                public string OriginalMessageId { get; set; }
+            }
+
+            public class SharedSessionGenericSaga : Saga<SharedSessionSagaData>, IAmStartedByMessages<GenericMessage>
+            {
+                readonly IAsyncDocumentSession ravenSession;
+                readonly RavenSessionTestContext testContext;
+
+                public SharedSessionGenericSaga(RavenSessionTestContext testContext, IAsyncDocumentSession ravenSession)
+                {
+                    this.testContext = testContext;
+                    this.ravenSession = ravenSession;
+                }
+
+                public Task Handle(GenericMessage message, IMessageHandlerContext context)
+                {
+                    testContext.RavenSessionFromHandler = ravenSession;
+                    testContext.HandlerWasHit = true;
+                    return Task.FromResult(0);
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SharedSessionSagaData> mapper) =>
+                    mapper.ConfigureMapping<GenericMessage>(m => m.Id).ToSaga(s => s.Id);
+            }
+
+            [Serializable]
+            public class GenericMessage : IMessage
+            {
+                public Guid Id { get; set; }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB/Internal/CurrentSessionBehavior.cs
+++ b/src/NServiceBus.RavenDB/Internal/CurrentSessionBehavior.cs
@@ -1,0 +1,24 @@
+﻿namespace NServiceBus.Persistence.RavenDB
+{
+    using System;
+    using System.Threading.Tasks;
+    using Pipeline;
+
+    class CurrentSessionBehavior : Behavior<IIncomingLogicalMessageContext>
+    {
+        readonly CurrentSessionHolder currentSessionHolder;
+
+        public CurrentSessionBehavior(CurrentSessionHolder currentSessionHolder)
+        {
+            this.currentSessionHolder = currentSessionHolder;
+        }
+
+        public override async Task Invoke(IIncomingLogicalMessageContext context, Func<Task> next)
+        {
+            using (currentSessionHolder.CreateScope())
+            {
+                await next().ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB/Internal/CurrentSessionHolder.cs
+++ b/src/NServiceBus.RavenDB/Internal/CurrentSessionHolder.cs
@@ -1,0 +1,50 @@
+﻿namespace NServiceBus.Persistence.RavenDB
+{
+    using System;
+    using System.Threading;
+    using Raven.Client.Documents.Session;
+
+    class CurrentSessionHolder
+    {
+        public IAsyncDocumentSession Current => pipelineContext.Value.Session;
+
+        public void SetCurrentSession(IAsyncDocumentSession session)
+        {
+            pipelineContext.Value.Session = session;
+        }
+
+        public IDisposable CreateScope()
+        {
+            if (pipelineContext.Value != null)
+            {
+                throw new InvalidOperationException("Attempt to overwrite an existing session context.");
+            }
+            var wrapper = new Wrapper();
+            pipelineContext.Value = wrapper;
+            return new Scope(this);
+        }
+
+        readonly AsyncLocal<Wrapper> pipelineContext = new AsyncLocal<Wrapper>();
+
+        class Wrapper
+        {
+            public IAsyncDocumentSession Session;
+        }
+
+        class Scope : IDisposable
+        {
+            public Scope(CurrentSessionHolder sessionHolder)
+            {
+                this.sessionHolder = sessionHolder;
+            }
+
+            public void Dispose()
+            {
+                sessionHolder.pipelineContext.Value = null;
+            }
+
+            readonly CurrentSessionHolder sessionHolder;
+        }
+
+    }
+}

--- a/src/NServiceBus.RavenDB/Internal/RavenDBSynchronizedStorage.cs
+++ b/src/NServiceBus.RavenDB/Internal/RavenDBSynchronizedStorage.cs
@@ -6,9 +6,10 @@
 
     class RavenDBSynchronizedStorage : ISynchronizedStorage
     {
-        public RavenDBSynchronizedStorage(IOpenTenantAwareRavenSessions sessionCreator)
+        public RavenDBSynchronizedStorage(IOpenTenantAwareRavenSessions sessionCreator, CurrentSessionHolder sessionHolder)
         {
             this.sessionCreator = sessionCreator;
+            this.sessionHolder = sessionHolder;
         }
 
         public Task<CompletableSynchronizedStorageSession> OpenSession(ContextBag context)
@@ -16,10 +17,12 @@
             var message = context.Get<IncomingMessage>();
             var session = sessionCreator.OpenSession(message.Headers);
             var synchronizedStorageSession = new RavenDBSynchronizedStorageSession(session, context, true);
+            sessionHolder?.SetCurrentSession(session);
 
             return Task.FromResult((CompletableSynchronizedStorageSession)synchronizedStorageSession);
         }
 
         IOpenTenantAwareRavenSessions sessionCreator;
+        readonly CurrentSessionHolder sessionHolder;
     }
 }


### PR DESCRIPTION
In [RavenDBSynchronizedStorage](https://github.com/Particular/NServiceBus.RavenDB/blob/master/src/NServiceBus.RavenDB/Internal/RavenDBSynchronizedStorage.cs#L14-L21), an `IAsyncSession` and the `SynchronizedStorageSession` that enables it to be shared with handlers is created, but not added to the `ContextBag`. That means that even when using the Outbox (meaning the sessions should be available from very early in the pipeline due to the dedupe check) you can't get at the session until the InvokeHandlers stage, unless you're willing to use reflection.

Related to https://github.com/Particular/NServiceBus.RavenDB/issues/532
Backport of #619 to 6.5