### PR TITLE
Log an error if the cluster topology has more than 1 node

### DIFF
--- a/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using NServiceBus.ConsistencyGuarantees;
+    using NServiceBus.Logging;
     using NServiceBus.ObjectBuilder;
     using NServiceBus.Settings;
     using Raven.Client.Documents;
@@ -111,6 +112,12 @@
 
                 var topology = getTopologyCmd.Result.Topology;
 
+                // Currently do not support clusters
+                if (topology.AllNodes.Count != 1)
+                {
+                    logger.Error("RavenDB Persistence does not support RavenDB clusters. Only single node setup is supported.");
+                }
+
                 // Currently do not support clusters with more than one possible primary member. Watchers (passive replication targets) are OK.
                 if (topology.Members.Count != 1)
                 {
@@ -123,5 +130,6 @@
         Func<ReadOnlySettings, IBuilder, IDocumentStore> storeCreator;
         IDocumentStore docStore;
         bool isInitialized;
+        static ILog logger = LogManager.GetLogger<DocumentStoreInitializer>();
     }
 }

--- a/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
@@ -115,7 +115,7 @@
                 // Currently do not support clusters
                 if (topology.AllNodes.Count != 1)
                 {
-                    logger.Error("RavenDB Persistence does not support RavenDB clusters. Only single node setup is supported.");
+                    logger.Error("RavenDB Persistence does not support RavenDB clusters with multiple nodes. Only a single node setup is supported.");
                 }
 
                 // Currently do not support clusters with more than one possible primary member. Watchers (passive replication targets) are OK.

--- a/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
@@ -115,7 +115,7 @@
                 // Currently do not support clusters
                 if (topology.AllNodes.Count != 1)
                 {
-                    logger.Error("RavenDB Persistence does not support RavenDB clusters with multiple nodes. Only a single node setup is supported.");
+                    logger.Error("RavenDB Persistence does not support RavenDB clusters with multiple nodes. Only a single-node configuration is supported.");
                 }
 
                 // Currently do not support clusters with more than one possible primary member. Watchers (passive replication targets) are OK.


### PR DESCRIPTION
In RavenDB any node in the cluster will accept writes, but they will be serialized across the cluster. The client will always send the request to the database primary. This means that in a cluster configuration there is an opportunity for different clients to write the same document concurrently and silently override each other.

Until https://github.com/Particular/NServiceBus.RavenDB/pull/624 is completed we cannot support cluster-based setups. Being a patch we cannot throw as we're doing in #661.