### PR TITLE
Check database topology instead of cluster topology

### DIFF
--- a/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
@@ -105,15 +105,13 @@
         {
             using (var s = store.OpenSession())
             {
-                var getTopologyCmd = new GetClusterTopologyCommand();
+                var getTopologyCmd = new GetDatabaseTopologyCommand();
                 s.Advanced.RequestExecutor.Execute(getTopologyCmd, s.Advanced.Context);
 
-                var topology = getTopologyCmd.Result.Topology;
-
                 // Currently do not support clusters.
-                if (topology.AllNodes.Count != 1)
+                if (getTopologyCmd.Result.Nodes.Count != 1)
                 {
-                    throw new InvalidOperationException("RavenDB Persistence does not support RavenDB clusters with multiple nodes. Only a single-node configuration is supported.");
+                    throw new InvalidOperationException("RavenDB Persistence does not support database groups with multiple database nodes. Only single-node configurations are supported.");
                 }
             }
         }


### PR DESCRIPTION
This uses `GetDatabaseTopologyCommand` instead of `GetClusterTopologyCommand` which gives more details about a specific databases configuration rather than the RavenDB server cluster.

This change allows users to use a single-node database without errors, even when multiple cluster-nodes have been configured. In this case, all read/write requests are handled by a single node which does not require cluster-wide transactions.
This might allow users to use a RavenDB cluster to host additional, replicated database nodes for other data while using a single-node database for NServiceBus persistence.