### PR TITLE
Make sure the RavenDB server is 5.2 or higher

### DIFF
--- a/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
@@ -81,11 +81,11 @@
 
             if (fullVersion.Major < requiredVersion.Major)
             {
-                throw new Exception("The RavenDB persistence requires RavenDB server 5.2 or higher");
+                throw new Exception($"We detected that the server is running on version {serverVersion.FullVersion}. RavenDB persistence requires RavenDB server 5.2 or higher");
             }
             if (fullVersion.Major == requiredVersion.Major && fullVersion.Minor < requiredVersion.Minor)
             {
-                throw new Exception("The RavenDB persistence requires RavenDB server 5.2 or higher");
+                throw new Exception($"We detected that the server is running on version {serverVersion.FullVersion}. RavenDB persistence requires RavenDB server 5.2 or higher");
             }
         }
 

--- a/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
@@ -60,10 +60,10 @@
             if (!isInitialized)
             {
                 EnsureDocStoreCreated(settings, builder);
-                EnsureCompatibleServerVersion(docStore);
                 ApplyConventions(settings);
 
                 docStore.Initialize();
+                EnsureCompatibleServerVersion(docStore);
                 EnsureClusterConfiguration(docStore);
 
                 CreateIndexes(docStore);

--- a/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
@@ -2,10 +2,8 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using ConsistencyGuarantees;
-    using Settings;
+    using NServiceBus.ConsistencyGuarantees;
+    using NServiceBus.Settings;
     using Raven.Client.Documents;
     using Raven.Client.Documents.Indexes;
     using Raven.Client.Documents.Operations.Indexes;
@@ -65,7 +63,7 @@
                 ApplyConventions(settings);
 
                 docStore.Initialize();
-                EnsureCompatibleServerVersion(docStore, CancellationToken.None).GetAwaiter().GetResult();
+                EnsureCompatibleServerVersion(docStore);
                 EnsureClusterConfiguration(docStore);
 
                 CreateIndexes(docStore);
@@ -75,10 +73,10 @@
             return docStore;
         }
 
-        async Task EnsureCompatibleServerVersion(IDocumentStore documentStore, CancellationToken cancellationToken)
+        void EnsureCompatibleServerVersion(IDocumentStore documentStore)
         {
             var requiredVersion = new Version(5, 2);
-            var serverVersion = await documentStore.Maintenance.Server.SendAsync(new GetBuildNumberOperation(), cancellationToken).ConfigureAwait(false);
+            var serverVersion = documentStore.Maintenance.Server.Send(new GetBuildNumberOperation());
             var fullVersion = new Version(serverVersion.FullVersion);
 
             if (fullVersion.Major < requiredVersion.Major ||

--- a/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
@@ -60,7 +60,7 @@
             if (!isInitialized)
             {
                 EnsureDocStoreCreated(settings, builder);
-                EnsureServerVersion(docStore);
+                EnsureCompatibleServerVersion(docStore);
                 ApplyConventions(settings);
 
                 docStore.Initialize();
@@ -73,7 +73,7 @@
             return docStore;
         }
 
-        void EnsureServerVersion(IDocumentStore documentStore)
+        void EnsureCompatibleServerVersion(IDocumentStore documentStore)
         {
             var requiredVersion = new Version(5, 2);
             var serverVersion = documentStore.Maintenance.Server.Send(new GetBuildNumberOperation());

--- a/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
+++ b/src/NServiceBus.RavenDB/Internal/DocumentStoreInitializer.cs
@@ -81,11 +81,8 @@
             var serverVersion = await documentStore.Maintenance.Server.SendAsync(new GetBuildNumberOperation(), cancellationToken).ConfigureAwait(false);
             var fullVersion = new Version(serverVersion.FullVersion);
 
-            if (fullVersion.Major < requiredVersion.Major)
-            {
-                throw new Exception($"We detected that the server is running on version {serverVersion.FullVersion}. RavenDB persistence requires RavenDB server 5.2 or higher");
-            }
-            if (fullVersion.Major == requiredVersion.Major && fullVersion.Minor < requiredVersion.Minor)
+            if (fullVersion.Major < requiredVersion.Major ||
+                (fullVersion.Major == requiredVersion.Major && fullVersion.Minor < requiredVersion.Minor))
             {
                 throw new Exception($"We detected that the server is running on version {serverVersion.FullVersion}. RavenDB persistence requires RavenDB server 5.2 or higher");
             }


### PR DESCRIPTION
To safely support cluster-wide transactions, we require the RavenDB server to be 5.2 or higher.