### PR TITLE
Make RavenDB Setup a dedicated job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
         uses: Particular/run-tests-action@v1.0.0
 
   cleanup:
-    runs-on: ubuntu-20.4
+    runs-on: ubuntu-20.04
     if: ${{ always() }}
     needs: [setup, build]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,11 +115,9 @@ jobs:
           curl "http://$($fqdnRavenDB['leader']):8080/admin/cluster/node?url=$($encodedURL)&tag=C&watcher=true&assignedCores=1" -X PUT -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
 
           $singlenodeurl = "http://$($fqdnRavenDB['singlenode']):8080"
-          echo "::add-mask::$singlenodeurl"
           echo "::set-output name=singlenodeurl::$singlenodeurl"
 
           $clusterurl = "http://$($fqdnRavenDB['leader']):8080,http://$($fqdnRavenDB['follower1']):8080,http://$($fqdnRavenDB['follower2']):8080"
-          echo "::add-mask::$clusterurl"
           echo "::set-output name=clusterurl::$clusterurl"
 
   build:
@@ -168,6 +166,11 @@ jobs:
           name: NuGet packages
           path: nugets/
           retention-days: 7
+      - name: Prepare for tests
+        shell: pwsh
+        run: |
+          echo "::add-mask::${{ needs.setup.outputs.singlenodeurl }}"
+          echo "::add-mask::${{ needs.setup.outputs.clusterurl }}"
       - name: Run tests
         env:
           RavenSingleNodeUrl: ${{ needs.setup.outputs.singlenodeurl }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           $encodedURL = [System.Web.HttpUtility]::UrlEncode("http://$($fqdnRavenDB['follower2']):8080")
           curl "http://$($fqdnRavenDB['leader']):8080/admin/cluster/node?url=$($encodedURL)&
 
-          $singlenodeurl = "http://$($fqdnRavenDB['singlenode']):8080";
+          $singlenodeurl = "http://$($fqdnRavenDB['singlenode']):8080"
           echo "::set-output name=singlenodeurl::$singlenodeurl"
           echo "::add-mask::$singlenodeurl"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
           name: NuGet packages
           path: nugets/
           retention-days: 7
-      - name: Download artifact
+      - name: Download Urls
         uses: actions/download-artifact@v2
         with:
           name: ravendburls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,6 @@ jobs:
 
           @($fqdnRavenDB.keys) | ForEach-Object -Parallel {
               $hashTable = $using:fqdnRavenDB;
-              echo "::add-mask::$hashTable[$_]"
               $tcpClient = New-Object Net.Sockets.TcpClient
               echo "Verifying connection $_"
               do
@@ -117,11 +116,9 @@ jobs:
 
           $singlenodeurl = "http://$($fqdnRavenDB['singlenode']):8080"
           echo "::set-output name=singlenodeurl::$singlenodeurl"
-          echo "::add-mask::$singlenodeurl"
 
           $clusterurl = "http://$($fqdnRavenDB['leader']):8080,http://$($fqdnRavenDB['follower1']):8080,http://$($fqdnRavenDB['follower2']):8080"
           echo "::set-output name=clusterurl::$clusterurl"
-          echo "::add-mask::$clusterurl"
 
   build:
     name: ${{ matrix.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,11 +167,10 @@ jobs:
           path: nugets/
           retention-days: 7
       - name: Prepare for tests
-        shell: pwsh
         run: |
-          $singlenodeurl = "${{ needs.setup.outputs.singlenodeurl }}"
+          singlenodeurl = "${{ needs.setup.outputs.singlenodeurl }}"
           echo "::add-mask::$singlenodeurl"
-          $clusterurl = "${{ needs.setup.outputs.clusterurl }}"
+          clusterurl = "${{ needs.setup.outputs.clusterurl }}"
           echo "::add-mask::$clusterurl"
       - name: Run tests
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,5 +185,5 @@ jobs:
         if: ${{ always() }}
         uses: Azure/powershell@v1
         with:
-          inlineScript: Get-AzContainerGroup -ResourceGroupName GitHubActions-RG | Where-Object { $_.Name -like "${{ needs.setup.outputs.prefix }}*" } | Remove-AzContainerGroup | Out-Null
+          inlineScript: Get-AzContainerGroup -ResourceGroupName GitHubActions-RG | Where-Object { $_.Name -like "${{ needs.setup.outputs.prefix }}*" } | Remove-AzContainerGroup
           azPSVersion: latest      

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,10 +170,13 @@ jobs:
         shell: pwsh
         run: |
           echo '::echo::off'
-          echo "RavenSingleNodeUrl=${{ needs.setup.outputs.singlenodeurl }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-          echo "CommaSeparatedRavenClusterUrls=${{ needs.setup.outputs.clusterurl }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          echo "::add-mask::${{ needs.setup.outputs.clusterurl }}"
+          echo "::add-mask::${{ needs.setup.outputs.clusterurl }}"
           echo '::echo::on'
       - name: Run tests
+        env:
+          RavenSingleNodeUrl: ${{ needs.setup.outputs.singlenodeurl }}
+          CommaSeparatedRavenClusterUrls: ${{ needs.setup.outputs.clusterurl }}
         uses: Particular/run-tests-action@v1.0.0
 
   cleanup:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,21 +67,22 @@ jobs:
 
           echo "::set-output name=prefix::$prefix"
 
-          $fqdnRavenDB = @(0, 1, 2, 3)
+          $fqdnRavenDB = @{ singlenode = ""; leader = ""; follower1 = ""; follower2 = "" }
 
           $NewRavenDBNodeDef = $function:NewRavenDBNode.ToString()
 
-          $fqdnRavenDB | ForEach-Object -Parallel {
+          @($fqdnRavenDB.keys) | ForEach-Object -Parallel {
               $function:NewRavenDBNode = $using:NewRavenDBNodeDef
               $region = $using:region;
               $prefix = $using:prefix;
               $detail = NewRavenDBNode $region $prefix $_ ${{ runner.os }} ${{ github.sha }}
-              $arr = $using:fqdnRavenDB;
-              $arr[$_] = $detail
+              $hashTable = $using:fqdnRavenDB;
+              $hashTable[$_] = $detail
           }
 
-          $fqdnRavenDB | ForEach-Object -Parallel {
-              echo "::add-mask::$_"
+          @($fqdnRavenDB.keys) | ForEach-Object -Parallel {
+              $hashTable = $using:fqdnRavenDB;
+              echo "::add-mask::$hashTable[$_]"
               $tcpClient = New-Object Net.Sockets.TcpClient
               echo "Verifying connection $_"
               do
@@ -89,7 +90,7 @@ jobs:
                   try
                   {
                       echo "Trying to connect to $_"
-                      $tcpClient.Connect($_, 8080)
+                      $tcpClient.Connect($hashTable[$_], 8080)
                       echo "Connection to $_ successful"
                   } catch 
                   {
@@ -101,22 +102,25 @@ jobs:
           }
 
           # Once you set the license on a node, it assumes the node to be a cluster, so only set the license on the leader
-          echo "Activating license on $($fqdnRavenDB[0])"
-          curl "http://$($fqdnRavenDB[0]):8080/admin/license/activate" -H 'Content-Type: application/json; charset=UTF-8' -d "$($license)"
+          echo "Activating license on singlenode"
+          curl "http://$($fqdnRavenDB['singlenode']):8080/admin/license/activate" -H 'Content-Type: application/json; charset=UTF-8' -d "$($license)"
 
           # Once you set the license on a node, it assumes the node to be a cluster, so only set the license on the leader
-          echo "Activating license on $($fqdnRavenDB[1])"
-          curl "http://$($fqdnRavenDB[1]):8080/admin/license/activate" -H 'Content-Type: application/json; charset=UTF-8' -d "$($license)"
+          echo "Activating license on leader"
+          curl "http://$($fqdnRavenDB['leader']):8080/admin/license/activate" -H 'Content-Type: application/json; charset=UTF-8' -d "$($license)"
 
-          curl "http://$($fqdnRavenDB[1]):8080/admin/license/set-limit?nodeTag=A&newAssignedCores=1" -X POST -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
-          $encodedURL = [System.Web.HttpUtility]::UrlEncode("http://$($fqdnRavenDB[2]):8080") 
-          curl "http://$($fqdnRavenDB[1]):8080/admin/cluster/node?url=$($encodedURL)&tag=B&watcher=true&assignedCores=1" -X PUT -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
-          $encodedURL = [System.Web.HttpUtility]::UrlEncode("http://$($fqdnRavenDB[3]):8080")
-          curl "http://$($fqdnRavenDB[1]):8080/admin/cluster/node?url=$($encodedURL)&tag=C&watcher=true&assignedCores=1" -X PUT -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
+          curl "http://$($fqdnRavenDB['leader']):8080/admin/license/set-limit?nodeTag=A&newAssignedCores=1" -X POST -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
+          $encodedURL = [System.Web.HttpUtility]::UrlEncode("http://$($fqdnRavenDB['follower1']):8080") 
+          curl "http://$($fqdnRavenDB['leader']):8080/admin/cluster/node?url=$($encodedURL)&tag=B&watcher=true&assignedCores=1" -X PUT -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
+          $encodedURL = [System.Web.HttpUtility]::UrlEncode("http://$($fqdnRavenDB['follower2']):8080")
+          curl "http://$($fqdnRavenDB['leader']):8080/admin/cluster/node?url=$($encodedURL)&
 
-          echo "::set-output name=singlenodeurl::http://$($fqdnRavenDB[0]):8080"
+          $singlenodeurl = "http://$($fqdnRavenDB['singlenode']):8080";
+          echo "::set-output name=singlenodeurl::$singlenodeurl"
           echo "::add-mask::singlenodeurl"
-          echo "::set-output name=clusterurl::http://$($fqdnRavenDB[1]):8080,http://$($fqdnRavenDB[2]):8080,http://$($fqdnRavenDB[3]):8080"
+
+          $clusterurl = "http://$($fqdnRavenDB['leader']):8080,http://$($fqdnRavenDB['follower1']):8080,http://$($fqdnRavenDB['follower2']):8080"
+          echo "::set-output name=clusterurl::$clusterurl"
           echo "::add-mask::clusterurl"
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       (github.event_name == 'pull_request_target' && github.event.pull_request.user.login == 'dependabot[bot]') ||
       (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]') ||
       github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    name: Setup RavenDB
+    name: Setup RavenDB Nodes
     runs-on: ubuntu-20.04
     outputs:
       prefix: ${{ steps.setup-ravendb.outputs.prefix }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,11 +117,11 @@ jobs:
 
           $singlenodeurl = "http://$($fqdnRavenDB['singlenode']):8080";
           echo "::set-output name=singlenodeurl::$singlenodeurl"
-          echo "::add-mask::singlenodeurl"
+          echo "::add-mask::$singlenodeurl"
 
           $clusterurl = "http://$($fqdnRavenDB['leader']):8080,http://$($fqdnRavenDB['follower1']):8080,http://$($fqdnRavenDB['follower2']):8080"
           echo "::set-output name=clusterurl::$clusterurl"
-          echo "::add-mask::clusterurl"
+          echo "::add-mask::$clusterurl"
 
   build:
     name: ${{ matrix.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,9 +169,9 @@ jobs:
       - name: Prepare for tests
         shell: pwsh
         run: |
-          $singlenodeurl = ${{ needs.setup.outputs.singlenodeurl }}
+          $singlenodeurl = "${{ needs.setup.outputs.singlenodeurl }}"
           echo "::add-mask::$singlenodeurl"
-          $clusterurl = ${{ needs.setup.outputs.clusterurl }}
+          $clusterurl = "${{ needs.setup.outputs.clusterurl }}"
           echo "::add-mask::$clusterurl"
       - name: Run tests
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,5 +185,5 @@ jobs:
         if: ${{ always() }}
         uses: Azure/powershell@v1
         with:
-          inlineScript: Get-AzContainerGroup -ResourceGroupName GitHubActions-RG | Where-Object { $_.Name -like "${{ needs.setup.outputs.prefix }}*" } | Remove-AzContainerGroup
+          inlineScript: Get-AzContainerGroup -ResourceGroupName GitHubActions-RG | Where-Object { $_.Name -like "${{ needs.setup.outputs.prefix }}*" } | Remove-AzContainerGroup | Out-Null
           azPSVersion: latest      

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,9 @@ jobs:
           curl "http://$($fqdnRavenDB[1]):8080/admin/cluster/node?url=$($encodedURL)&tag=C&watcher=true&assignedCores=1" -X PUT -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
 
           echo "::set-output name=singlenodeurl::http://$($fqdnRavenDB[0]):8080"
+          echo "::add-mask::singlenodeurl"
           echo "::set-output name=clusterurl::http://$($fqdnRavenDB[1]):8080,http://$($fqdnRavenDB[2]):8080,http://$($fqdnRavenDB[3]):8080"
+          echo "::add-mask::clusterurl"
 
   build:
     name: ${{ matrix.name }}
@@ -163,12 +165,10 @@ jobs:
           name: NuGet packages
           path: nugets/
           retention-days: 7
-      - name: Prepare Environment for tests
-        shell: pwsh
-        run: |
-          echo "RavenSingleNodeUrl=${{ needs.setup.outputs.singlenodeurl }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-          echo "CommaSeparatedRavenClusterUrls=${{ needs.setup.outputs.clusterurl }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
       - name: Run tests
+        env:
+          RavenSingleNodeUrl: ${{ needs.setup.outputs.singlenodeurl }}
+          CommaSeparatedRavenClusterUrls: ${{ needs.setup.outputs.clusterurl }}
         uses: Particular/run-tests-action@v1.0.0
 
   cleanup:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,55 +14,16 @@ on:
 env:
   DOTNET_NOLOGO: true
 jobs:
-  build:
+  setup:
     if:
       (github.event_name == 'pull_request_target' && github.event.pull_request.user.login == 'dependabot[bot]') ||
       (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]') ||
       github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: windows-2019
-            name: Windows
-          - os: ubuntu-20.04
-            name: Linux
-      fail-fast: false
+    name: Setup RavenDB
+    runs-on: ubuntu-20.04
+    outputs:
+      prefix: ${{ steps.setup-ravendb.outputs.prefix }}
     steps:
-      - name: Check for secrets
-        env:
-          SECRETS_AVAILABLE: ${{ secrets.SECRETS_AVAILABLE }}
-        shell: pwsh
-        run: exit $(If ($env:SECRETS_AVAILABLE -eq 'true') { 0 } Else { 1 })
-      - name: Checkout
-        if: github.event_name != 'pull_request_target'
-        uses: actions/checkout@v2.4.0
-        with:
-          fetch-depth: 0
-      - name: Checkout for Dependabot
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v2.4.0
-        with:
-          ref: 'refs/pull/${{ github.event.number }}/merge'
-          fetch-depth: 0
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v1.8.2
-        with:
-          dotnet-version: 5.0.x
-      - name: Setup .NET Core 3.1 runtime
-        uses: actions/setup-dotnet@v1.8.2
-        with:
-          dotnet-version: 3.1.x
-      - name: Build
-        run: dotnet build src --configuration Release
-      - name: Upload packages
-        if: matrix.name == 'Windows'
-        uses: actions/upload-artifact@v2.2.4
-        with:
-          name: NuGet packages
-          path: nugets/
-          retention-days: 7
       - name: Azure login
         uses: azure/login@v1.4.1
         with:
@@ -154,11 +115,68 @@ jobs:
           echo "RavenSingleNodeUrl=http://$($fqdnRavenDB[0]):8080" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           echo "CommaSeparatedRavenClusterUrls=http://$($fqdnRavenDB[1]):8080,http://$($fqdnRavenDB[2]):8080,http://$($fqdnRavenDB[3]):8080" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
 
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    needs: setup
+    strategy:
+      matrix:
+        include:
+          - os: windows-2019
+            name: Windows
+          - os: ubuntu-20.04
+            name: Linux
+      fail-fast: false
+    steps:
+      - name: Check for secrets
+        env:
+          SECRETS_AVAILABLE: ${{ secrets.SECRETS_AVAILABLE }}
+        shell: pwsh
+        run: exit $(If ($env:SECRETS_AVAILABLE -eq 'true') { 0 } Else { 1 })
+      - name: Checkout
+        if: github.event_name != 'pull_request_target'
+        uses: actions/checkout@v2.4.0
+        with:
+          fetch-depth: 0
+      - name: Checkout for Dependabot
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: 'refs/pull/${{ github.event.number }}/merge'
+          fetch-depth: 0
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v1.8.2
+        with:
+          dotnet-version: 5.0.x
+      - name: Setup .NET Core 3.1 runtime
+        uses: actions/setup-dotnet@v1.8.2
+        with:
+          dotnet-version: 3.1.x
+      - name: Build
+        run: dotnet build src --configuration Release
+      - name: Upload packages
+        if: matrix.name == 'Windows'
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: NuGet packages
+          path: nugets/
+          retention-days: 7
       - name: Run tests
         uses: Particular/run-tests-action@v1.0.0
+
+  cleanup:
+    runs-on: ubuntu-20.4
+    if: ${{ always() }}
+    needs: [setup, build]
+    steps:
+      - name: Azure login
+        uses: azure/login@v1.4.1
+        with:
+          creds: ${{ secrets.AZURE_ACI_CREDENTIALS }}
+          enable-AzPSSession: true
       - name: Teardown RavenDB
         if: ${{ always() }}
         uses: Azure/powershell@v1
         with:
-          inlineScript: Get-AzContainerGroup -ResourceGroupName GitHubActions-RG | Where-Object { $_.Name -like "${{ steps.setup-ravendb.outputs.prefix }}*" } | Remove-AzContainerGroup | Out-Null
+          inlineScript: Get-AzContainerGroup -ResourceGroupName GitHubActions-RG | Where-Object { $_.Name -like "${{ needs.setup.outputs.prefix }}*" } | Remove-AzContainerGroup | Out-Null
           azPSVersion: latest      

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
           path: nugets/
           retention-days: 7
       - name: Prepare Environment for tests
-        shell: psw
+        shell: pwsh
         run: |
           echo "RavenSingleNodeUrl=${{ needs.setup.outputs.singlenodeurl }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           echo "CommaSeparatedRavenClusterUrls=${{ needs.setup.outputs.clusterurl }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,8 +170,10 @@ jobs:
         run: |
           singlenodeurl = "${{ needs.setup.outputs.singlenodeurl }}"
           echo "::add-mask::$singlenodeurl"
+          echo "::set-output name=singlenodeurl::$singlenodeurl"
           clusterurl = "${{ needs.setup.outputs.clusterurl }}"
           echo "::add-mask::$clusterurl"
+          echo "::set-output name=clusterurl::$clusterurl"
       - name: Run tests
         env:
           RavenSingleNodeUrl: ${{ needs.setup.outputs.singlenodeurl }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,8 +169,10 @@ jobs:
       - name: Prepare for tests
         shell: pwsh
         run: |
-          echo "::add-mask::${{ needs.setup.outputs.singlenodeurl }}"
-          echo "::add-mask::${{ needs.setup.outputs.clusterurl }}"
+          $singlenodeurl = ${{ needs.setup.outputs.singlenodeurl }}
+          echo "::add-mask::$singlenodeurl"
+          $clusterurl = ${{ needs.setup.outputs.clusterurl }}
+          echo "::add-mask::$clusterurl"
       - name: Run tests
         env:
           RavenSingleNodeUrl: ${{ needs.setup.outputs.singlenodeurl }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       prefix: ${{ steps.setup-ravendb.outputs.prefix }}
-      singlenodeurl: ${{ steps.setup-ravendb.outputs.singlenodeurl }}
-      clusterurl: ${{ steps.setup-ravendb.outputs.clusterurl }}
     steps:
       - name: Azure login
         uses: azure/login@v1.4.1
@@ -116,14 +114,17 @@ jobs:
 
           $singlenodeurl = "http://$($fqdnRavenDB['singlenode']):8080"
           echo "::set-output name=singlenodeurl::$singlenodeurl"
+          echo "::add-mask::$singlenodeurl"
 
           $clusterurl = "http://$($fqdnRavenDB['leader']):8080,http://$($fqdnRavenDB['follower1']):8080,http://$($fqdnRavenDB['follower2']):8080"
           echo "::set-output name=clusterurl::$clusterurl"
-      - name: Run a one-line script
+          echo "::add-mask::$clusterurl"
+      - name: Encrypt Urls
         run: |
+          # Unfortunately masking breaks job outputs so we go the extra mile
           echo ${{ steps.setup-ravendb.outputs.singlenodeurl }} | gpg --quiet --symmetric --cipher-algo AES256 --batch --yes --passphrase '${{ secrets.PASSPHRASE }}' --output singlenodeurl.txt.gpg
           echo ${{ steps.setup-ravendb.outputs.clusterurl }} | gpg --quiet --symmetric --cipher-algo AES256 --batch --yes --passphrase '${{ secrets.PASSPHRASE }}' --output clusterurl.txt.gpg
-      - name: 'Upload Artifact'
+      - name: Upload Urls
         uses: actions/upload-artifact@v2
         with:
           name: ravendburls
@@ -185,6 +186,7 @@ jobs:
         id: prepare
         shell: pwsh
         run: |
+          # Unfortunately masking breaks job outputs so we go the extra mile
           gpg --quiet --batch --yes --decrypt --passphrase='${{ secrets.PASSPHRASE }}' --output singlenodeurl.txt singlenodeurl.txt.gpg
           gpg --quiet --batch --yes --decrypt --passphrase='${{ secrets.PASSPHRASE }}' --output clusterurl.txt clusterurl.txt.gpg
           $singlenodeurl = cat singlenodeurl.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
           $encodedURL = [System.Web.HttpUtility]::UrlEncode("http://$($fqdnRavenDB['follower1']):8080") 
           curl "http://$($fqdnRavenDB['leader']):8080/admin/cluster/node?url=$($encodedURL)&tag=B&watcher=true&assignedCores=1" -X PUT -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
           $encodedURL = [System.Web.HttpUtility]::UrlEncode("http://$($fqdnRavenDB['follower2']):8080")
-          curl "http://$($fqdnRavenDB['leader']):8080/admin/cluster/node?url=$($encodedURL)&
+          curl "http://$($fqdnRavenDB['leader']):8080/admin/cluster/node?url=$($encodedURL)&tag=C&watcher=true&assignedCores=1" -X PUT -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
 
           $singlenodeurl = "http://$($fqdnRavenDB['singlenode']):8080"
           echo "::set-output name=singlenodeurl::$singlenodeurl"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,18 @@ jobs:
 
           $clusterurl = "http://$($fqdnRavenDB['leader']):8080,http://$($fqdnRavenDB['follower1']):8080,http://$($fqdnRavenDB['follower2']):8080"
           echo "::set-output name=clusterurl::$clusterurl"
-
+      - name: Run a one-line script
+        run: |
+          echo ${{ steps.setup-ravendb.outputs.singlenodeurl }} | gpg --quiet --symmetric --cipher-algo AES256 --batch --yes --passphrase '${{ secrets.PASSPHRASE }}' --output singlenodeurl.txt.gpg
+          echo ${{ steps.setup-ravendb.outputs.clusterurl }} | gpg --quiet --symmetric --cipher-algo AES256 --batch --yes --passphrase '${{ secrets.PASSPHRASE }}' --output clusterurl.txt.gpg
+      - name: 'Upload Artifact'
+        uses: actions/upload-artifact@v2
+        with:
+          name: ravendburls
+          path: |
+            singlenodeurl.txt.gpg
+            clusterurl.txt.gpg
+          retention-days: 1
   build:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -166,17 +177,26 @@ jobs:
           name: NuGet packages
           path: nugets/
           retention-days: 7
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ravendburls
       - name: Prepare for tests
+        id: prepare
         shell: pwsh
         run: |
-          echo '::echo::off'
-          echo "::add-mask::${{ needs.setup.outputs.clusterurl }}"
-          echo "::add-mask::${{ needs.setup.outputs.clusterurl }}"
-          echo '::echo::on'
+          gpg --quiet --batch --yes --decrypt --passphrase='${{ secrets.PASSPHRASE }}' --output singlenodeurl.txt singlenodeurl.txt.gpg
+          gpg --quiet --batch --yes --decrypt --passphrase='${{ secrets.PASSPHRASE }}' --output clusterurl.txt clusterurl.txt.gpg
+          $singlenodeurl = cat singlenodeurl.txt
+          echo "::add-mask::$singlenodeurl"
+          echo "::set-output name=singlenodeurl::$singlenodeurl"
+          $clusterurl = cat clusterurl.txt
+          echo "::add-mask::$clusterurl"
+          echo "::set-output name=clusterurl::$clusterurl"
       - name: Run tests
         env:
-          RavenSingleNodeUrl: ${{ needs.setup.outputs.singlenodeurl }}
-          CommaSeparatedRavenClusterUrls: ${{ needs.setup.outputs.clusterurl }}
+          RavenSingleNodeUrl: ${{ steps.prepare.outputs.singlenodeurl }}
+          CommaSeparatedRavenClusterUrls: ${{ steps.prepare.outputs.clusterurl }}
         uses: Particular/run-tests-action@v1.0.0
 
   cleanup:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,8 +169,10 @@ jobs:
       - name: Prepare for tests
         shell: pwsh
         run: |
+          echo '::echo::off'
           echo "RavenSingleNodeUrl=${{ needs.setup.outputs.singlenodeurl }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           echo "CommaSeparatedRavenClusterUrls=${{ needs.setup.outputs.clusterurl }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          echo '::echo::on'
       - name: Run tests
         uses: Particular/run-tests-action@v1.0.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       prefix: ${{ steps.setup-ravendb.outputs.prefix }}
+      singlenodeurl: ${{ steps.setup-ravendb.outputs.singlenodeurl }}
+      clusterurl: ${{ steps.setup-ravendb.outputs.clusterurl }}
     steps:
       - name: Azure login
         uses: azure/login@v1.4.1
@@ -112,8 +114,8 @@ jobs:
           $encodedURL = [System.Web.HttpUtility]::UrlEncode("http://$($fqdnRavenDB[3]):8080")
           curl "http://$($fqdnRavenDB[1]):8080/admin/cluster/node?url=$($encodedURL)&tag=C&watcher=true&assignedCores=1" -X PUT -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
 
-          echo "RavenSingleNodeUrl=http://$($fqdnRavenDB[0]):8080" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-          echo "CommaSeparatedRavenClusterUrls=http://$($fqdnRavenDB[1]):8080,http://$($fqdnRavenDB[2]):8080,http://$($fqdnRavenDB[3]):8080" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          echo "::set-output name=singlenodeurl::http://$($fqdnRavenDB[0]):8080"
+          echo "::set-output name=clusterurl::http://$($fqdnRavenDB[1]):8080,http://$($fqdnRavenDB[2]):8080,http://$($fqdnRavenDB[3]):8080"
 
   build:
     name: ${{ matrix.name }}
@@ -161,6 +163,11 @@ jobs:
           name: NuGet packages
           path: nugets/
           retention-days: 7
+      - name: Prepare Environment for tests
+        shell: psw
+        run: |
+          echo "RavenSingleNodeUrl=${{ needs.setup.outputs.singlenodeurl }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          echo "CommaSeparatedRavenClusterUrls=${{ needs.setup.outputs.clusterurl }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
       - name: Run tests
         uses: Particular/run-tests-action@v1.0.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,17 +167,11 @@ jobs:
           path: nugets/
           retention-days: 7
       - name: Prepare for tests
+        shell: pwsh
         run: |
-          singlenodeurl = "${{ needs.setup.outputs.singlenodeurl }}"
-          echo "::add-mask::$singlenodeurl"
-          echo "::set-output name=singlenodeurl::$singlenodeurl"
-          clusterurl = "${{ needs.setup.outputs.clusterurl }}"
-          echo "::add-mask::$clusterurl"
-          echo "::set-output name=clusterurl::$clusterurl"
+          echo "RavenSingleNodeUrl=${{ needs.setup.outputs.singlenodeurl }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          echo "CommaSeparatedRavenClusterUrls=${{ needs.setup.outputs.clusterurl }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
       - name: Run tests
-        env:
-          RavenSingleNodeUrl: ${{ needs.setup.outputs.singlenodeurl }}
-          CommaSeparatedRavenClusterUrls: ${{ needs.setup.outputs.clusterurl }}
         uses: Particular/run-tests-action@v1.0.0
 
   cleanup:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,9 +115,11 @@ jobs:
           curl "http://$($fqdnRavenDB['leader']):8080/admin/cluster/node?url=$($encodedURL)&tag=C&watcher=true&assignedCores=1" -X PUT -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
 
           $singlenodeurl = "http://$($fqdnRavenDB['singlenode']):8080"
+          echo "::add-mask::$singlenodeurl"
           echo "::set-output name=singlenodeurl::$singlenodeurl"
 
           $clusterurl = "http://$($fqdnRavenDB['leader']):8080,http://$($fqdnRavenDB['follower1']):8080,http://$($fqdnRavenDB['follower2']):8080"
+          echo "::add-mask::$clusterurl"
           echo "::set-output name=clusterurl::$clusterurl"
 
   build:


### PR DESCRIPTION
This PR Runs the ravendb setup in a dedicated job so that the cluster and the single node can be shared with the tests on Windows and Linux. With that, we are creating less container instances. The tests run independent databases anyway.

Unfortunately, there seems to be a [bug in the job outputs](https://github.com/actions/runner/issues/1498). When you combine them with masking, they break, so I had to go the extra mile of encrypting the FQDNs.