### PR TITLE
New metadata endpoint API version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         id: setup-ravendb
         shell: pwsh
         run: |
-          $hostInfo = curl -H Metadata:true "169.254.169.254/metadata/instance?api-version=2017-08-01" | ConvertFrom-Json
+          $hostInfo = curl -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | ConvertFrom-Json
           $region = $hostInfo.compute.location
           $license = '${{ secrets.RAVENDB_LICENSE }}'
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service

Should hopefully solve the SetupRavenDB failures

https://github.com/Particular/NServiceBus.RavenDB/runs/4292206474?check_suite_focus=true