### PR TITLE
Simplify the outbox compare exchange handling by leveraging the document expiry

### DIFF
--- a/src/NServiceBus.RavenDB.AcceptanceTests/NServiceBus.RavenDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/NServiceBus.RavenDB.AcceptanceTests.csproj
@@ -10,11 +10,11 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="RavenDB.Client" Version="5.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.RavenDB.ClusterWide.AcceptanceTests/NServiceBus.RavenDB.ClusterWide.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.ClusterWide.AcceptanceTests/NServiceBus.RavenDB.ClusterWide.AcceptanceTests.csproj
@@ -11,11 +11,11 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="RavenDB.Client" Version="5.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.RavenDB.ClusterWide.Tests/NServiceBus.RavenDB.ClusterWide.Tests.csproj
+++ b/src/NServiceBus.RavenDB.ClusterWide.Tests/NServiceBus.RavenDB.ClusterWide.Tests.csproj
@@ -12,14 +12,14 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NServiceBus" Version="8.0.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
     <PackageReference Include="Particular.Approvals" Version="0.3.0" />
-    <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
-    <PackageReference Include="RavenDB.Client" Version="5.3.2" />
+    <PackageReference Include="PublicApiGenerator" Version="10.3.0" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.RavenDB.Optimistic.AcceptanceTests/NServiceBus.RavenDB.Optimistic.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.Optimistic.AcceptanceTests/NServiceBus.RavenDB.Optimistic.AcceptanceTests.csproj
@@ -11,11 +11,11 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="RavenDB.Client" Version="5.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.RavenDB.Optimistic.ClusterWide.AcceptanceTests/NServiceBus.RavenDB.Optimistic.ClusterWide.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.Optimistic.ClusterWide.AcceptanceTests/NServiceBus.RavenDB.Optimistic.ClusterWide.AcceptanceTests.csproj
@@ -11,11 +11,11 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="RavenDB.Client" Version="5.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.RavenDB.PersistenceTests/NServiceBus.RavenDB.PersistenceTests.csproj
+++ b/src/NServiceBus.RavenDB.PersistenceTests/NServiceBus.RavenDB.PersistenceTests.csproj
@@ -13,11 +13,11 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NServiceBus.PersistenceTests.Sources" Version="8.0.0" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="RavenDB.Client" Version="5.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.5" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.RavenDB.PersistenceTests/NServiceBus.RavenDB.PersistenceTests.csproj
+++ b/src/NServiceBus.RavenDB.PersistenceTests/NServiceBus.RavenDB.PersistenceTests.csproj
@@ -20,4 +20,9 @@
     <PackageReference Include="RavenDB.Client" Version="5.4.5" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- To remove when https://github.com/Particular/NServiceBus/pull/6603 is merged and released  -->
+    <Compile Remove="$(PkgNServiceBus_PersistenceTests_Sources)\**\When_updating_saga_concurrently_on_same_thread.cs" />
+    <Compile Remove="$(PkgNServiceBus_PersistenceTests_Sources)\**\When_updating_saga_concurrently_twice_on_the_same_thread.cs" />
+  </ItemGroup>
 </Project>

--- a/src/NServiceBus.RavenDB.PersistenceTests/When_updating_saga_concurrently_on_same_thread.cs
+++ b/src/NServiceBus.RavenDB.PersistenceTests/When_updating_saga_concurrently_on_same_thread.cs
@@ -1,0 +1,87 @@
+namespace NServiceBus.PersistenceTesting.Sagas
+{
+    using System;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using NUnit.Framework;
+    using Persistence;
+
+    public class When_updating_saga_concurrently_on_same_thread : SagaPersisterTests
+    {
+        [Test]
+        public async Task Save_should_fail_when_data_changes_between_read_and_update()
+        {
+            configuration.RequiresOptimisticConcurrencySupport();
+
+            var correlationPropertyData = Guid.NewGuid().ToString();
+            var sagaData = new TestSagaData { SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
+            await SaveSaga(sagaData);
+            var generatedSagaId = sagaData.Id;
+
+            ContextBag losingContext;
+            ICompletableSynchronizedStorageSession losingSaveSession;
+            TestSagaData staleRecord;
+            var persister = configuration.SagaStorage;
+
+            var winningContext = configuration.GetContextBagForSagaStorage();
+            using (var winningSaveSession = configuration.CreateStorageSession())
+            {
+                await winningSaveSession.Open(winningContext);
+
+                var record = await persister.Get<TestSagaData>(generatedSagaId, winningSaveSession, winningContext);
+
+                losingContext = configuration.GetContextBagForSagaStorage();
+                losingSaveSession = configuration.CreateStorageSession();
+                await losingSaveSession.Open(losingContext);
+                staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession, losingContext);
+
+                record.DateTimeProperty = DateTime.UtcNow;
+                await persister.Update(record, winningSaveSession, winningContext);
+                await winningSaveSession.CompleteAsync();
+            }
+
+            try
+            {
+                staleRecord.DateTimeProperty = DateTime.UtcNow.AddHours(1);
+                Assert.CatchAsync<Exception>(async () =>
+                {
+                    await persister.Update(staleRecord, losingSaveSession, losingContext);
+                    await losingSaveSession.CompleteAsync();
+                });
+            }
+            finally
+            {
+                losingSaveSession.Dispose();
+            }
+        }
+
+        public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartMessage>
+        {
+            public Task Handle(StartMessage message, IMessageHandlerContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper)
+            {
+                mapper.ConfigureMapping<StartMessage>(msg => msg.SomeId).ToSaga(saga => saga.SomeId);
+            }
+        }
+
+        public class StartMessage
+        {
+            public string SomeId { get; set; }
+        }
+
+        public class TestSagaData : ContainSagaData
+        {
+            public string SomeId { get; set; } = "Test";
+
+            public DateTime DateTimeProperty { get; set; }
+        }
+
+        public When_updating_saga_concurrently_on_same_thread(TestVariant param) : base(param)
+        {
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB.PersistenceTests/When_updating_saga_concurrently_twice_on_the_same_thread.cs
+++ b/src/NServiceBus.RavenDB.PersistenceTests/When_updating_saga_concurrently_twice_on_the_same_thread.cs
@@ -1,0 +1,132 @@
+namespace NServiceBus.PersistenceTesting.Sagas
+{
+    using System;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using NUnit.Framework;
+    using Persistence;
+
+    public class When_updating_saga_concurrently_twice_on_the_same_thread : SagaPersisterTests
+    {
+        [Test]
+        public async Task Save_process_is_repeatable()
+        {
+            configuration.RequiresOptimisticConcurrencySupport();
+
+            var correlationPropertyData = Guid.NewGuid().ToString();
+            var saga = new TestSagaData { SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
+            await SaveSaga(saga);
+
+            ContextBag losingContext1;
+            ICompletableSynchronizedStorageSession losingSaveSession1;
+            TestSagaData staleRecord1;
+            var persister = configuration.SagaStorage;
+
+            var winningContext1 = configuration.GetContextBagForSagaStorage();
+            var winningSaveSession1 = configuration.CreateStorageSession();
+            await winningSaveSession1.Open(winningContext1);
+
+            try
+            {
+                var record1 = await persister.Get<TestSagaData>(saga.Id, winningSaveSession1, winningContext1);
+
+                losingContext1 = configuration.GetContextBagForSagaStorage();
+                losingSaveSession1 = configuration.CreateStorageSession();
+                await losingSaveSession1.Open(losingContext1);
+
+                staleRecord1 = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession1, losingContext1);
+
+                record1.DateTimeProperty = DateTime.UtcNow;
+                await persister.Update(record1, winningSaveSession1, winningContext1);
+                await winningSaveSession1.CompleteAsync();
+            }
+            finally
+            {
+                winningSaveSession1.Dispose();
+            }
+
+            try
+            {
+                staleRecord1.DateTimeProperty = DateTime.UtcNow.AddHours(1);
+                Assert.That(async () =>
+                {
+                    await persister.Update(staleRecord1, losingSaveSession1, losingContext1);
+                    await losingSaveSession1.CompleteAsync();
+                }, Throws.InstanceOf<Exception>());
+            }
+            finally
+            {
+                losingSaveSession1.Dispose();
+            }
+
+            ContextBag losingContext2;
+            ICompletableSynchronizedStorageSession losingSaveSession2;
+            TestSagaData staleRecord2;
+
+            var winningContext2 = configuration.GetContextBagForSagaStorage();
+            var winningSaveSession2 = configuration.CreateStorageSession();
+            await winningSaveSession2.Open(winningContext2);
+            try
+            {
+                var record2 = await persister.Get<TestSagaData>(saga.Id, winningSaveSession2, winningContext2);
+
+                losingContext2 = configuration.GetContextBagForSagaStorage();
+                losingSaveSession2 = configuration.CreateStorageSession();
+                await losingSaveSession2.Open(losingContext2);
+
+                staleRecord2 = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession2, losingContext2);
+
+                record2.DateTimeProperty = DateTime.UtcNow;
+                await persister.Update(record2, winningSaveSession2, winningContext2);
+                await winningSaveSession2.CompleteAsync();
+            }
+            finally
+            {
+                winningSaveSession2.Dispose();
+            }
+
+            try
+            {
+                staleRecord2.DateTimeProperty = DateTime.UtcNow.AddHours(1);
+                Assert.That(async () =>
+                 {
+                     await persister.Update(staleRecord2, losingSaveSession2, losingContext2);
+                     await losingSaveSession2.CompleteAsync();
+                 }, Throws.InstanceOf<Exception>());
+            }
+            finally
+            {
+                losingSaveSession2.Dispose();
+            }
+        }
+
+        public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartMessage>
+        {
+            public Task Handle(StartMessage message, IMessageHandlerContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper)
+            {
+                mapper.ConfigureMapping<StartMessage>(msg => msg.SomeId).ToSaga(saga => saga.SomeId);
+            }
+        }
+
+        public class StartMessage
+        {
+            public string SomeId { get; set; }
+        }
+
+        public class TestSagaData : ContainSagaData
+        {
+            public string SomeId { get; set; } = "Test";
+
+            public DateTime DateTimeProperty { get; set; }
+        }
+
+        public When_updating_saga_concurrently_twice_on_the_same_thread(TestVariant param) : base(param)
+        {
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
+++ b/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
@@ -12,14 +12,14 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NServiceBus" Version="8.0.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
     <PackageReference Include="Particular.Approvals" Version="0.3.0" />
-    <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
-    <PackageReference Include="RavenDB.Client" Version="5.3.2" />
+    <PackageReference Include="PublicApiGenerator" Version="10.3.0" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.5" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.RavenDB.TransactionalSession.AcceptanceTests/NServiceBus.RavenDB.TransactionalSession.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.TransactionalSession.AcceptanceTests/NServiceBus.RavenDB.TransactionalSession.AcceptanceTests.csproj
@@ -16,12 +16,12 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0" />
     <PackageReference Include="NServiceBus.TransactionalSession" Version="2.0.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="RavenDB.Client" Version="5.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.5" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
+++ b/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="NServiceBus" Version="[8.0.0, 9)" />
     <PackageReference Include="Obsolete.Fody" Version="5.3.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="2.2.0" PrivateAssets="All" />
-    <PackageReference Include="RavenDB.Client" Version="[5.2.100, 6.0.0)" />
+    <PackageReference Include="RavenDB.Client" Version="[5.2.107, 6.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
+++ b/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="NServiceBus" Version="[8.0.0, 9)" />
     <PackageReference Include="Obsolete.Fody" Version="5.3.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="2.2.0" PrivateAssets="All" />
-    <PackageReference Include="RavenDB.Client" Version="[5.2.1, 6.0.0)" />
+    <PackageReference Include="RavenDB.Client" Version="[5.2.100, 6.0.0)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Like https://github.com/Particular/NServiceBus.RavenDB/pull/1024 but for `release-8.0`