### PR TITLE
Loading the atomic guard isn't needed as we add the expiration of the document to the atomic guard

### DIFF
--- a/src/NServiceBus.RavenDB.AcceptanceTests/NServiceBus.RavenDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/NServiceBus.RavenDB.AcceptanceTests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
-    <PackageReference Include="RavenDB.Client" Version="5.4.1" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.5" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(PkgNServiceBus_AcceptanceTests_Sources)' != ''">

--- a/src/NServiceBus.RavenDB.AcceptanceTests/NServiceBus.RavenDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/NServiceBus.RavenDB.AcceptanceTests.csproj
@@ -11,35 +11,35 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
-    <PackageReference Include="RavenDB.Client" Version="5.3.0" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.1" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Remove="\**\ConfigureEndpointInMemoryPersistence.cs" />
-    <Compile Remove="\**\ConfigureEndpointLearningPersistence.cs" />
-    <Compile Remove="\**\ConventionEnforcementTests.cs" />
-    <Compile Remove="\**\DeterministicGuid.cs" />
-    <Compile Remove="\**\Audit\*.*" />
-    <Compile Remove="\**\Correlation\*.*" />
-    <Compile Remove="\**\DataBus\*.*" />
-    <Compile Remove="\**\DelayedDelivery\*.*" />
-    <Compile Remove="\**\Forwarding\*.*" />
-    <Compile Remove="\**\MessageId\*.*" />
-    <Compile Remove="\**\Pipeline\*.*" />
-    <Compile Remove="\**\Recoverability\*.*" />
-    <Compile Remove="\**\Routing\NativePublishSubscribe\*.*" />
-    <Compile Remove="\**\Satellites\*.*" />
-    <Compile Remove="\**\Scheduling\*.*" />
-    <Compile Remove="\**\SelfVerification\*.*" />
-    <Compile Remove="\**\Serialization\*.*" />
-    <Compile Remove="\**\TimeToBeReceived\*.*" />
-    <Compile Remove="\**\Tx\**\*.*" />
-    <Compile Remove="\**\Versioning\*.*" />
+  <ItemGroup Condition="'$(PkgNServiceBus_AcceptanceTests_Sources)' != ''">
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\ConfigureEndpointInMemoryPersistence.cs" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\ConfigureEndpointLearningPersistence.cs" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\ConventionEnforcementTests.cs" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\DeterministicGuid.cs" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Audit\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Correlation\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\DataBus\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\DelayedDelivery\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Forwarding\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\MessageId\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Pipeline\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Recoverability\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Routing\NativePublishSubscribe\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Satellites\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Scheduling\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\SelfVerification\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Serialization\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\TimeToBeReceived\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Tx\**\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Versioning\*.*" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.RavenDB.ClusterWide.AcceptanceTests/NServiceBus.RavenDB.ClusterWide.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.ClusterWide.AcceptanceTests/NServiceBus.RavenDB.ClusterWide.AcceptanceTests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="3.13.2"/>
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0"/>
-    <PackageReference Include="RavenDB.Client" Version="5.4.1"/>
+    <PackageReference Include="RavenDB.Client" Version="5.4.5"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.RavenDB.ClusterWide.AcceptanceTests/NServiceBus.RavenDB.ClusterWide.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.ClusterWide.AcceptanceTests/NServiceBus.RavenDB.ClusterWide.AcceptanceTests.csproj
@@ -12,39 +12,39 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0"/>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0"/>
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0"/>
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="3.13.2"/>
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0"/>
-    <PackageReference Include="RavenDB.Client" Version="5.3.0"/>
+    <PackageReference Include="RavenDB.Client" Version="5.4.1"/>
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\**\*.cs" Exclude="**\obj\**"/>
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Remove="\**\ConfigureEndpointInMemoryPersistence.cs"/>
-    <Compile Remove="\**\ConfigureEndpointLearningPersistence.cs"/>
-    <Compile Remove="\**\ConventionEnforcementTests.cs"/>
-    <Compile Remove="\**\DeterministicGuid.cs"/>
-    <Compile Remove="\**\Audit\*.*"/>
-    <Compile Remove="\**\Correlation\*.*"/>
-    <Compile Remove="\**\DataBus\*.*"/>
-    <Compile Remove="\**\DelayedDelivery\*.*"/>
-    <Compile Remove="\**\Forwarding\*.*"/>
-    <Compile Remove="\**\MessageId\*.*"/>
-    <Compile Remove="\**\Pipeline\*.*"/>
-    <Compile Remove="\**\Recoverability\*.*"/>
-    <Compile Remove="\**\Routing\NativePublishSubscribe\*.*"/>
-    <Compile Remove="\**\Satellites\*.*"/>
-    <Compile Remove="\**\Scheduling\*.*"/>
-    <Compile Remove="\**\SelfVerification\*.*"/>
-    <Compile Remove="\**\Serialization\*.*"/>
-    <Compile Remove="\**\TimeToBeReceived\*.*"/>
-    <Compile Remove="\**\Tx\**\*.*"/>
-    <Compile Remove="\**\Versioning\*.*"/>
+  <ItemGroup Condition="'$(PkgNServiceBus_AcceptanceTests_Sources)' != ''">
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\ConfigureEndpointInMemoryPersistence.cs"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\ConfigureEndpointLearningPersistence.cs"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\ConventionEnforcementTests.cs"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\DeterministicGuid.cs"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Audit\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Correlation\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\DataBus\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\DelayedDelivery\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Forwarding\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\MessageId\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Pipeline\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Recoverability\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Routing\NativePublishSubscribe\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Satellites\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Scheduling\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\SelfVerification\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Serialization\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\TimeToBeReceived\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Tx\**\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Versioning\*.*"/>
 
     <Compile Remove="..\NServiceBus.RavenDB.AcceptanceTests\When_storing_saga_with_high_contention.cs"/>
     <Compile Remove="..\NServiceBus.RavenDB.AcceptanceTests\ConfigureEndpointRavenDBPersistence.cs"/>

--- a/src/NServiceBus.RavenDB.ClusterWide.Tests/NServiceBus.RavenDB.ClusterWide.Tests.csproj
+++ b/src/NServiceBus.RavenDB.ClusterWide.Tests/NServiceBus.RavenDB.ClusterWide.Tests.csproj
@@ -20,7 +20,7 @@
         <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
         <PackageReference Include="Particular.Approvals" Version="0.3.0" />
         <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
-        <PackageReference Include="RavenDB.Client" Version="5.4.1" />
+        <PackageReference Include="RavenDB.Client" Version="5.4.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NServiceBus.RavenDB.ClusterWide.Tests/NServiceBus.RavenDB.ClusterWide.Tests.csproj
+++ b/src/NServiceBus.RavenDB.ClusterWide.Tests/NServiceBus.RavenDB.ClusterWide.Tests.csproj
@@ -12,7 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
+        <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
         <PackageReference Include="NServiceBus" Version="7.5.0" />
@@ -20,7 +20,7 @@
         <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
         <PackageReference Include="Particular.Approvals" Version="0.3.0" />
         <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
-        <PackageReference Include="RavenDB.Client" Version="5.3.0" />
+        <PackageReference Include="RavenDB.Client" Version="5.4.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NServiceBus.RavenDB.Optimistic.AcceptanceTests/NServiceBus.RavenDB.Optimistic.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.Optimistic.AcceptanceTests/NServiceBus.RavenDB.Optimistic.AcceptanceTests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
-    <PackageReference Include="RavenDB.Client" Version="5.4.1" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.RavenDB.Optimistic.AcceptanceTests/NServiceBus.RavenDB.Optimistic.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.Optimistic.AcceptanceTests/NServiceBus.RavenDB.Optimistic.AcceptanceTests.csproj
@@ -8,48 +8,48 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\NServiceBus.RavenDB\NServiceBus.RavenDB.csproj"/>
+    <ProjectReference Include="..\NServiceBus.RavenDB\NServiceBus.RavenDB.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0"/>
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0"/>
-    <PackageReference Include="NUnit" Version="3.13.2"/>
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0"/>
-    <PackageReference Include="RavenDB.Client" Version="5.3.0"/>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0" GeneratePathProperty="true" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\**\*.cs" Exclude="**\obj\**"/>
+    <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\**\*.cs" Exclude="**\obj\**" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Remove="\**\ConfigureEndpointInMemoryPersistence.cs"/>
-    <Compile Remove="\**\ConfigureEndpointLearningPersistence.cs"/>
-    <Compile Remove="\**\ConventionEnforcementTests.cs"/>
-    <Compile Remove="\**\DeterministicGuid.cs"/>
-    <Compile Remove="\**\Audit\*.*"/>
-    <Compile Remove="\**\Correlation\*.*"/>
-    <Compile Remove="\**\DataBus\*.*"/>
-    <Compile Remove="\**\DelayedDelivery\*.*"/>
-    <Compile Remove="\**\Forwarding\*.*"/>
-    <Compile Remove="\**\MessageId\*.*"/>
-    <Compile Remove="\**\Pipeline\*.*"/>
-    <Compile Remove="\**\Recoverability\*.*"/>
-    <Compile Remove="\**\Routing\NativePublishSubscribe\*.*"/>
-    <Compile Remove="\**\Satellites\*.*"/>
-    <Compile Remove="\**\Scheduling\*.*"/>
-    <Compile Remove="\**\SelfVerification\*.*"/>
-    <Compile Remove="\**\Serialization\*.*"/>
-    <Compile Remove="\**\TimeToBeReceived\*.*"/>
-    <Compile Remove="\**\Tx\**\*.*"/>
-    <Compile Remove="\**\Versioning\*.*"/>
+  <ItemGroup Condition="'$(PkgNServiceBus_AcceptanceTests_Sources)' != ''">
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\ConfigureEndpointInMemoryPersistence.cs" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\ConfigureEndpointLearningPersistence.cs" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\ConventionEnforcementTests.cs" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\DeterministicGuid.cs" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Audit\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Correlation\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\DataBus\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\DelayedDelivery\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Forwarding\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\MessageId\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Pipeline\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Recoverability\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Routing\NativePublishSubscribe\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Satellites\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Scheduling\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\SelfVerification\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Serialization\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\TimeToBeReceived\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Tx\**\*.*" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Versioning\*.*" />
 
     <!-- The high contention test is only relevant for pessimistic concurrency control -->
-    <Compile Remove="..\NServiceBus.RavenDB.AcceptanceTests\When_storing_saga_with_high_contention.cs"/>
-    <Compile Remove="..\NServiceBus.RavenDB.AcceptanceTests\ConfigureEndpointRavenDBPersistence.cs"/>
-    <Compile Remove="..\NServiceBus.RavenDB.AcceptanceTests\TestSuiteConstraints.cs"/>
+    <Compile Remove="..\NServiceBus.RavenDB.AcceptanceTests\When_storing_saga_with_high_contention.cs" />
+    <Compile Remove="..\NServiceBus.RavenDB.AcceptanceTests\ConfigureEndpointRavenDBPersistence.cs" />
+    <Compile Remove="..\NServiceBus.RavenDB.AcceptanceTests\TestSuiteConstraints.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.RavenDB.Optimistic.ClusterWide.AcceptanceTests/NServiceBus.RavenDB.Optimistic.ClusterWide.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.Optimistic.ClusterWide.AcceptanceTests/NServiceBus.RavenDB.Optimistic.ClusterWide.AcceptanceTests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="3.13.2"/>
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0"/>
-    <PackageReference Include="RavenDB.Client" Version="5.4.1"/>
+    <PackageReference Include="RavenDB.Client" Version="5.4.5"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.RavenDB.Optimistic.ClusterWide.AcceptanceTests/NServiceBus.RavenDB.Optimistic.ClusterWide.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.Optimistic.ClusterWide.AcceptanceTests/NServiceBus.RavenDB.Optimistic.ClusterWide.AcceptanceTests.csproj
@@ -12,39 +12,39 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0"/>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0"/>
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0"/>
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="3.13.2"/>
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0"/>
-    <PackageReference Include="RavenDB.Client" Version="5.3.0"/>
+    <PackageReference Include="RavenDB.Client" Version="5.4.1"/>
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\NServiceBus.RavenDB.AcceptanceTests\**\*.cs" Exclude="**\obj\**"/>
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Remove="\**\ConfigureEndpointInMemoryPersistence.cs"/>
-    <Compile Remove="\**\ConfigureEndpointLearningPersistence.cs"/>
-    <Compile Remove="\**\ConventionEnforcementTests.cs"/>
-    <Compile Remove="\**\DeterministicGuid.cs"/>
-    <Compile Remove="\**\Audit\*.*"/>
-    <Compile Remove="\**\Correlation\*.*"/>
-    <Compile Remove="\**\DataBus\*.*"/>
-    <Compile Remove="\**\DelayedDelivery\*.*"/>
-    <Compile Remove="\**\Forwarding\*.*"/>
-    <Compile Remove="\**\MessageId\*.*"/>
-    <Compile Remove="\**\Pipeline\*.*"/>
-    <Compile Remove="\**\Recoverability\*.*"/>
-    <Compile Remove="\**\Routing\NativePublishSubscribe\*.*"/>
-    <Compile Remove="\**\Satellites\*.*"/>
-    <Compile Remove="\**\Scheduling\*.*"/>
-    <Compile Remove="\**\SelfVerification\*.*"/>
-    <Compile Remove="\**\Serialization\*.*"/>
-    <Compile Remove="\**\TimeToBeReceived\*.*"/>
-    <Compile Remove="\**\Tx\**\*.*"/>
-    <Compile Remove="\**\Versioning\*.*"/>
+  <ItemGroup Condition="'$(PkgNServiceBus_AcceptanceTests_Sources)' != ''">
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\ConfigureEndpointInMemoryPersistence.cs"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\ConfigureEndpointLearningPersistence.cs"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\ConventionEnforcementTests.cs"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\DeterministicGuid.cs"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Audit\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Correlation\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\DataBus\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\DelayedDelivery\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Forwarding\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\MessageId\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Pipeline\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Recoverability\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Routing\NativePublishSubscribe\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Satellites\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Scheduling\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\SelfVerification\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Serialization\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\TimeToBeReceived\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Tx\**\*.*"/>
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Versioning\*.*"/>
 
     <!-- The high contention test is only relevant for pessimistic concurrency control -->
     <Compile Remove="..\NServiceBus.RavenDB.AcceptanceTests\When_storing_saga_with_high_contention.cs"/>

--- a/src/NServiceBus.RavenDB.PersistenceTests/NServiceBus.RavenDB.PersistenceTests.csproj
+++ b/src/NServiceBus.RavenDB.PersistenceTests/NServiceBus.RavenDB.PersistenceTests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="NServiceBus.PersistenceTests.Sources" Version="7.5.0" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
-    <PackageReference Include="RavenDB.Client" Version="5.4.1" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.5" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(PkgNServiceBus_PersistenceTests_Sources)' != ''">

--- a/src/NServiceBus.RavenDB.PersistenceTests/NServiceBus.RavenDB.PersistenceTests.csproj
+++ b/src/NServiceBus.RavenDB.PersistenceTests/NServiceBus.RavenDB.PersistenceTests.csproj
@@ -12,17 +12,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NServiceBus.PersistenceTests.Sources" Version="7.5.0" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
-    <PackageReference Include="RavenDB.Client" Version="5.3.0" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.1" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(PkgNServiceBus_PersistenceTests_Sources)' != ''">
     <!-- Remove once https://github.com/Particular/NServiceBus/pull/6210 is merged and new version released -->
-    <Compile Remove="$(PkgNServiceBus_PersistenceTests_Sources)\**\Sagas\When_concurrent_update_exceed_lock_request_timeout_pessimistic.cs" />
+    <Compile Remove="$(PkgNServiceBus_PersistenceTests_Sources)\**\Sagas\When_concurrent_update_exceed_lock_request_timeout_pessimistic.cs"  />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.RavenDB.PersistenceTests/NServiceBus.RavenDB.PersistenceTests.csproj
+++ b/src/NServiceBus.RavenDB.PersistenceTests/NServiceBus.RavenDB.PersistenceTests.csproj
@@ -23,6 +23,8 @@
   <ItemGroup Condition="'$(PkgNServiceBus_PersistenceTests_Sources)' != ''">
     <!-- Remove once https://github.com/Particular/NServiceBus/pull/6210 is merged and new version released -->
     <Compile Remove="$(PkgNServiceBus_PersistenceTests_Sources)\**\Sagas\When_concurrent_update_exceed_lock_request_timeout_pessimistic.cs"  />
+    <!-- To remove when https://github.com/Particular/NServiceBus/pull/6603 is merged and released  -->
+    <Compile Remove="$(PkgNServiceBus_PersistenceTests_Sources)\**\When_updating_saga_concurrently_on_same_thread.cs" />
+    <Compile Remove="$(PkgNServiceBus_PersistenceTests_Sources)\**\When_updating_saga_concurrently_twice_on_the_same_thread.cs" />
   </ItemGroup>
-
 </Project>

--- a/src/NServiceBus.RavenDB.PersistenceTests/When_updating_saga_concurrently_on_same_thread.cs
+++ b/src/NServiceBus.RavenDB.PersistenceTests/When_updating_saga_concurrently_on_same_thread.cs
@@ -1,0 +1,87 @@
+namespace NServiceBus.PersistenceTesting.Sagas
+{
+    using System;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using NUnit.Framework;
+    using Persistence;
+
+    public class When_updating_saga_concurrently_on_same_thread : SagaPersisterTests
+    {
+        [Test]
+        public async Task Save_should_fail_when_data_changes_between_read_and_update()
+        {
+            configuration.RequiresOptimisticConcurrencySupport();
+
+            var correlationPropertyData = Guid.NewGuid().ToString();
+            var sagaData = new TestSagaData { SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
+            await SaveSaga(sagaData);
+            var generatedSagaId = sagaData.Id;
+
+            ContextBag losingContext;
+            ICompletableSynchronizedStorageSession losingSaveSession;
+            TestSagaData staleRecord;
+            var persister = configuration.SagaStorage;
+
+            var winningContext = configuration.GetContextBagForSagaStorage();
+            using (var winningSaveSession = configuration.CreateStorageSession())
+            {
+                await winningSaveSession.Open(winningContext);
+
+                var record = await persister.Get<TestSagaData>(generatedSagaId, winningSaveSession, winningContext);
+
+                losingContext = configuration.GetContextBagForSagaStorage();
+                losingSaveSession = configuration.CreateStorageSession();
+                await losingSaveSession.Open(losingContext);
+                staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession, losingContext);
+
+                record.DateTimeProperty = DateTime.UtcNow;
+                await persister.Update(record, winningSaveSession, winningContext);
+                await winningSaveSession.CompleteAsync();
+            }
+
+            try
+            {
+                staleRecord.DateTimeProperty = DateTime.UtcNow.AddHours(1);
+                Assert.CatchAsync<Exception>(async () =>
+                {
+                    await persister.Update(staleRecord, losingSaveSession, losingContext);
+                    await losingSaveSession.CompleteAsync();
+                });
+            }
+            finally
+            {
+                losingSaveSession.Dispose();
+            }
+        }
+
+        public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartMessage>
+        {
+            public Task Handle(StartMessage message, IMessageHandlerContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper)
+            {
+                mapper.ConfigureMapping<StartMessage>(msg => msg.SomeId).ToSaga(saga => saga.SomeId);
+            }
+        }
+
+        public class StartMessage
+        {
+            public string SomeId { get; set; }
+        }
+
+        public class TestSagaData : ContainSagaData
+        {
+            public string SomeId { get; set; } = "Test";
+
+            public DateTime DateTimeProperty { get; set; }
+        }
+
+        public When_updating_saga_concurrently_on_same_thread(TestVariant param) : base(param)
+        {
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB.PersistenceTests/When_updating_saga_concurrently_twice_on_the_same_thread.cs
+++ b/src/NServiceBus.RavenDB.PersistenceTests/When_updating_saga_concurrently_twice_on_the_same_thread.cs
@@ -1,0 +1,132 @@
+namespace NServiceBus.PersistenceTesting.Sagas
+{
+    using System;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using NUnit.Framework;
+    using Persistence;
+
+    public class When_updating_saga_concurrently_twice_on_the_same_thread : SagaPersisterTests
+    {
+        [Test]
+        public async Task Save_process_is_repeatable()
+        {
+            configuration.RequiresOptimisticConcurrencySupport();
+
+            var correlationPropertyData = Guid.NewGuid().ToString();
+            var saga = new TestSagaData { SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
+            await SaveSaga(saga);
+
+            ContextBag losingContext1;
+            ICompletableSynchronizedStorageSession losingSaveSession1;
+            TestSagaData staleRecord1;
+            var persister = configuration.SagaStorage;
+
+            var winningContext1 = configuration.GetContextBagForSagaStorage();
+            var winningSaveSession1 = configuration.CreateStorageSession();
+            await winningSaveSession1.Open(winningContext1);
+
+            try
+            {
+                var record1 = await persister.Get<TestSagaData>(saga.Id, winningSaveSession1, winningContext1);
+
+                losingContext1 = configuration.GetContextBagForSagaStorage();
+                losingSaveSession1 = configuration.CreateStorageSession();
+                await losingSaveSession1.Open(losingContext1);
+
+                staleRecord1 = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession1, losingContext1);
+
+                record1.DateTimeProperty = DateTime.UtcNow;
+                await persister.Update(record1, winningSaveSession1, winningContext1);
+                await winningSaveSession1.CompleteAsync();
+            }
+            finally
+            {
+                winningSaveSession1.Dispose();
+            }
+
+            try
+            {
+                staleRecord1.DateTimeProperty = DateTime.UtcNow.AddHours(1);
+                Assert.That(async () =>
+                {
+                    await persister.Update(staleRecord1, losingSaveSession1, losingContext1);
+                    await losingSaveSession1.CompleteAsync();
+                }, Throws.InstanceOf<Exception>());
+            }
+            finally
+            {
+                losingSaveSession1.Dispose();
+            }
+
+            ContextBag losingContext2;
+            ICompletableSynchronizedStorageSession losingSaveSession2;
+            TestSagaData staleRecord2;
+
+            var winningContext2 = configuration.GetContextBagForSagaStorage();
+            var winningSaveSession2 = configuration.CreateStorageSession();
+            await winningSaveSession2.Open(winningContext2);
+            try
+            {
+                var record2 = await persister.Get<TestSagaData>(saga.Id, winningSaveSession2, winningContext2);
+
+                losingContext2 = configuration.GetContextBagForSagaStorage();
+                losingSaveSession2 = configuration.CreateStorageSession();
+                await losingSaveSession2.Open(losingContext2);
+
+                staleRecord2 = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession2, losingContext2);
+
+                record2.DateTimeProperty = DateTime.UtcNow;
+                await persister.Update(record2, winningSaveSession2, winningContext2);
+                await winningSaveSession2.CompleteAsync();
+            }
+            finally
+            {
+                winningSaveSession2.Dispose();
+            }
+
+            try
+            {
+                staleRecord2.DateTimeProperty = DateTime.UtcNow.AddHours(1);
+                Assert.That(async () =>
+                 {
+                     await persister.Update(staleRecord2, losingSaveSession2, losingContext2);
+                     await losingSaveSession2.CompleteAsync();
+                 }, Throws.InstanceOf<Exception>());
+            }
+            finally
+            {
+                losingSaveSession2.Dispose();
+            }
+        }
+
+        public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartMessage>
+        {
+            public Task Handle(StartMessage message, IMessageHandlerContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper)
+            {
+                mapper.ConfigureMapping<StartMessage>(msg => msg.SomeId).ToSaga(saga => saga.SomeId);
+            }
+        }
+
+        public class StartMessage
+        {
+            public string SomeId { get; set; }
+        }
+
+        public class TestSagaData : ContainSagaData
+        {
+            public string SomeId { get; set; } = "Test";
+
+            public DateTime DateTimeProperty { get; set; }
+        }
+
+        public When_updating_saga_concurrently_twice_on_the_same_thread(TestVariant param) : base(param)
+        {
+        }
+    }
+}

--- a/src/NServiceBus.RavenDB.PersistenceTests/When_updating_saga_concurrently_twice_on_the_same_thread.cs
+++ b/src/NServiceBus.RavenDB.PersistenceTests/When_updating_saga_concurrently_twice_on_the_same_thread.cs
@@ -18,21 +18,19 @@ namespace NServiceBus.PersistenceTesting.Sagas
             await SaveSaga(saga);
 
             ContextBag losingContext1;
-            ICompletableSynchronizedStorageSession losingSaveSession1;
+            CompletableSynchronizedStorageSession losingSaveSession1;
             TestSagaData staleRecord1;
             var persister = configuration.SagaStorage;
 
             var winningContext1 = configuration.GetContextBagForSagaStorage();
-            var winningSaveSession1 = configuration.CreateStorageSession();
-            await winningSaveSession1.Open(winningContext1);
+            var winningSaveSession1 = await configuration.SynchronizedStorage.OpenSession(winningContext1);
 
             try
             {
                 var record1 = await persister.Get<TestSagaData>(saga.Id, winningSaveSession1, winningContext1);
 
                 losingContext1 = configuration.GetContextBagForSagaStorage();
-                losingSaveSession1 = configuration.CreateStorageSession();
-                await losingSaveSession1.Open(losingContext1);
+                losingSaveSession1 = await configuration.SynchronizedStorage.OpenSession(losingContext1);
 
                 staleRecord1 = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession1, losingContext1);
 
@@ -60,19 +58,17 @@ namespace NServiceBus.PersistenceTesting.Sagas
             }
 
             ContextBag losingContext2;
-            ICompletableSynchronizedStorageSession losingSaveSession2;
+            CompletableSynchronizedStorageSession losingSaveSession2;
             TestSagaData staleRecord2;
 
             var winningContext2 = configuration.GetContextBagForSagaStorage();
-            var winningSaveSession2 = configuration.CreateStorageSession();
-            await winningSaveSession2.Open(winningContext2);
+            var winningSaveSession2 = await configuration.SynchronizedStorage.OpenSession(winningContext2);
             try
             {
                 var record2 = await persister.Get<TestSagaData>(saga.Id, winningSaveSession2, winningContext2);
 
                 losingContext2 = configuration.GetContextBagForSagaStorage();
-                losingSaveSession2 = configuration.CreateStorageSession();
-                await losingSaveSession2.Open(losingContext2);
+                losingSaveSession2 = await configuration.SynchronizedStorage.OpenSession(losingContext2);
 
                 staleRecord2 = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession2, losingContext2);
 

--- a/src/NServiceBus.RavenDB.PessimisticLock.AcceptanceTests/NServiceBus.RavenDB.PessimisticLock.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.PessimisticLock.AcceptanceTests/NServiceBus.RavenDB.PessimisticLock.AcceptanceTests.csproj
@@ -12,12 +12,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="RavenDB.Client" Version="4.2.103" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.RavenDB.PessimisticLock.AcceptanceTests/NServiceBus.RavenDB.PessimisticLock.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.PessimisticLock.AcceptanceTests/NServiceBus.RavenDB.PessimisticLock.AcceptanceTests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="RavenDB.Client" Version="5.4.1" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
+++ b/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
     <PackageReference Include="Particular.Approvals" Version="0.3.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
-    <PackageReference Include="RavenDB.Client" Version="5.4.1" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.5" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
+++ b/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
@@ -12,14 +12,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NServiceBus" Version="7.5.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
     <PackageReference Include="Particular.Approvals" Version="0.3.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
-    <PackageReference Include="RavenDB.Client" Version="5.3.0" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.1" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
+++ b/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="NServiceBus" Version="[7.0.0, 8.0.0)" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="2.0.0" PrivateAssets="All" />
-    <PackageReference Include="RavenDB.Client" Version="[5.2.1, 6.0.0)" />
+    <PackageReference Include="RavenDB.Client" Version="[5.2.100, 6.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
+++ b/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="NServiceBus" Version="[7.0.0, 8.0.0)" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="2.0.0" PrivateAssets="All" />
-    <PackageReference Include="RavenDB.Client" Version="[5.2.100, 6.0.0)" />
+    <PackageReference Include="RavenDB.Client" Version="[5.2.107, 6.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.RavenDB/Outbox/OutboxPersister.cs
+++ b/src/NServiceBus.RavenDB/Outbox/OutboxPersister.cs
@@ -10,7 +10,6 @@
     using Raven.Client;
     using Raven.Client.Documents.Commands.Batches;
     using Raven.Client.Documents.Operations;
-    using Raven.Client.Documents.Operations.CompareExchange;
     using Raven.Client.Documents.Session;
     using Raven.Client.Exceptions;
     using TransportOperation = Outbox.TransportOperation;
@@ -107,16 +106,7 @@
                 var outboxRecordId = GetOutboxRecordId(messageId);
                 if (useClusterWideTransactions)
                 {
-                    var compareExchangeKey = $"rvn-atomic/{outboxRecordId}";
-                    var outboxRecord = await session.LoadAsync<OutboxRecord>(outboxRecordId, includes => includes.IncludeCompareExchangeValue(outboxRecordId))
-                        .ConfigureAwait(false);
-                    var compareExchangeValue = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<CompareExchangeValue<string>>(compareExchangeKey)
-                        .ConfigureAwait(false);
-
-                    if (compareExchangeValue == null)
-                    {
-                        throw new Exception("The compare exchange value for the outbox could not be found.");
-                    }
+                    var outboxRecord = await session.LoadAsync<OutboxRecord>(outboxRecordId).ConfigureAwait(false);
 
                     if (!outboxRecord.Dispatched)
                     {
@@ -130,7 +120,6 @@
                         if (timeToKeepDeduplicationData != Timeout.InfiniteTimeSpan)
                         {
                             metadata.Add(Constants.Documents.Metadata.Expires, DateTime.UtcNow.Add(timeToKeepDeduplicationData));
-                            compareExchangeValue.Metadata.Add(Constants.Documents.Metadata.Expires, DateTime.UtcNow.Add(timeToKeepDeduplicationData));
                         }
                     }
                 }
@@ -175,7 +164,7 @@
                 }
                 catch (ConcurrencyException) when (useClusterWideTransactions)
                 {
-                    // When cluster wide transactions are enabled and two concurrent operations try to set as dispatched 
+                    // When cluster wide transactions are enabled and two concurrent operations try to set as dispatched
                     // it is OK to swallow the exception since the outcome is deterministic
                     // patching for non cluster wide transactions would always work and never land here
                 }


### PR DESCRIPTION
Addresses #1044

- Like https://github.com/Particular/NServiceBus.RavenDB/pull/1024 but for `release-7.0`