### PR TITLE
Switch Subscriptions to newly introduced async aggressive caching to reduce potential thread starvation problems

### DIFF
--- a/src/NServiceBus.RavenDB.AcceptanceTests/NServiceBus.RavenDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/NServiceBus.RavenDB.AcceptanceTests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="RavenDB.Client" Version="5.4.5" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.100" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.RavenDB.ClusterWide.AcceptanceTests/NServiceBus.RavenDB.ClusterWide.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.ClusterWide.AcceptanceTests/NServiceBus.RavenDB.ClusterWide.AcceptanceTests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="RavenDB.Client" Version="5.4.5" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.100" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.RavenDB.ClusterWide.Tests/NServiceBus.RavenDB.ClusterWide.Tests.csproj
+++ b/src/NServiceBus.RavenDB.ClusterWide.Tests/NServiceBus.RavenDB.ClusterWide.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
     <PackageReference Include="Particular.Approvals" Version="0.3.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.3.0" />
-    <PackageReference Include="RavenDB.Client" Version="5.4.5" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.100" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.RavenDB.Optimistic.AcceptanceTests/NServiceBus.RavenDB.Optimistic.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.Optimistic.AcceptanceTests/NServiceBus.RavenDB.Optimistic.AcceptanceTests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="RavenDB.Client" Version="5.4.5" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.100" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.RavenDB.Optimistic.ClusterWide.AcceptanceTests/NServiceBus.RavenDB.Optimistic.ClusterWide.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.Optimistic.ClusterWide.AcceptanceTests/NServiceBus.RavenDB.Optimistic.ClusterWide.AcceptanceTests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="RavenDB.Client" Version="5.4.5" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.100" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.RavenDB.PersistenceTests/NServiceBus.RavenDB.PersistenceTests.csproj
+++ b/src/NServiceBus.RavenDB.PersistenceTests/NServiceBus.RavenDB.PersistenceTests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="NServiceBus.PersistenceTests.Sources" Version="8.0.0" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="RavenDB.Client" Version="5.4.5" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.100" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
+++ b/src/NServiceBus.RavenDB.Tests/NServiceBus.RavenDB.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
     <PackageReference Include="Particular.Approvals" Version="0.3.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.3.0" />
-    <PackageReference Include="RavenDB.Client" Version="5.4.5" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.100" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.RavenDB.TransactionalSession.AcceptanceTests/NServiceBus.RavenDB.TransactionalSession.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.TransactionalSession.AcceptanceTests/NServiceBus.RavenDB.TransactionalSession.AcceptanceTests.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="NServiceBus.TransactionalSession" Version="2.0.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="RavenDB.Client" Version="5.4.5" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.100" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
+++ b/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="NServiceBus" Version="[8.0.0, 9)" />
     <PackageReference Include="Obsolete.Fody" Version="5.3.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="2.2.0" PrivateAssets="All" />
-    <PackageReference Include="RavenDB.Client" Version="[5.2.107, 6.0.0)" />
+    <PackageReference Include="RavenDB.Client" Version="[5.4.100, 6.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.RavenDB/Subscriptions/SubscriptionPersister.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/SubscriptionPersister.cs
@@ -87,8 +87,6 @@ namespace NServiceBus.Persistence.RavenDB
 
         public async Task Unsubscribe(Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken = default)
         {
-            var subscriptionClient = new SubscriptionClient { TransportAddress = subscriber.TransportAddress, Endpoint = subscriber.Endpoint };
-
             using var session = OpenAsyncSession();
             var subscriptionDocId = GetDocumentIdForMessageType(messageType);
 
@@ -99,6 +97,7 @@ namespace NServiceBus.Persistence.RavenDB
                 return;
             }
 
+            var subscriptionClient = new SubscriptionClient { TransportAddress = subscriber.TransportAddress, Endpoint = subscriber.Endpoint };
             if (subscription.Subscribers.Contains(subscriptionClient))
             {
                 subscription.Subscribers.Remove(subscriptionClient);

--- a/src/NServiceBus.RavenDB/Subscriptions/SubscriptionPersister.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/SubscriptionPersister.cs
@@ -169,8 +169,8 @@ namespace NServiceBus.Persistence.RavenDB
             return session;
         }
 
-        IDocumentStore documentStore;
-        bool useClusterWideTransactions;
+        readonly IDocumentStore documentStore;
+        readonly bool useClusterWideTransactions;
 
         sealed class EmptyDisposable : IDisposable
         {

--- a/src/NServiceBus.RavenDB/Subscriptions/SubscriptionPersister.cs
+++ b/src/NServiceBus.RavenDB/Subscriptions/SubscriptionPersister.cs
@@ -42,40 +42,38 @@ namespace NServiceBus.Persistence.RavenDB
             {
                 try
                 {
-                    using (var session = OpenAsyncSession())
+                    using var session = OpenAsyncSession();
+                    var subscriptionDocId = GetDocumentIdForMessageType(messageType);
+
+                    var subscription = await session.LoadAsync<Subscription>(subscriptionDocId, cancellationToken).ConfigureAwait(false);
+
+                    if (subscription == null)
                     {
-                        var subscriptionDocId = GetDocumentIdForMessageType(messageType);
-
-                        var subscription = await session.LoadAsync<Subscription>(subscriptionDocId, cancellationToken).ConfigureAwait(false);
-
-                        if (subscription == null)
+                        subscription = new Subscription
                         {
-                            subscription = new Subscription
-                            {
-                                Id = subscriptionDocId,
-                                MessageType = messageType,
-                                Subscribers = new List<SubscriptionClient>()
-                            };
+                            Id = subscriptionDocId,
+                            MessageType = messageType,
+                            Subscribers = new List<SubscriptionClient>()
+                        };
 
-                            await session.StoreAsync(subscription, cancellationToken).ConfigureAwait(false);
-                            session.StoreSchemaVersionInMetadata(subscription);
-                        }
-
-                        if (!subscription.Subscribers.Contains(subscriptionClient))
-                        {
-                            subscription.Subscribers.Add(subscriptionClient);
-                        }
-                        else
-                        {
-                            var savedSubscription = subscription.Subscribers.Single(s => s.Equals(subscriptionClient));
-                            if (savedSubscription.Endpoint != subscriber.Endpoint)
-                            {
-                                savedSubscription.Endpoint = subscriber.Endpoint;
-                            }
-                        }
-
-                        await session.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                        await session.StoreAsync(subscription, cancellationToken).ConfigureAwait(false);
+                        session.StoreSchemaVersionInMetadata(subscription);
                     }
+
+                    if (!subscription.Subscribers.Contains(subscriptionClient))
+                    {
+                        subscription.Subscribers.Add(subscriptionClient);
+                    }
+                    else
+                    {
+                        var savedSubscription = subscription.Subscribers.Single(s => s.Equals(subscriptionClient));
+                        if (savedSubscription.Endpoint != subscriber.Endpoint)
+                        {
+                            savedSubscription.Endpoint = subscriber.Endpoint;
+                        }
+                    }
+
+                    await session.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
                     return;
                 }
@@ -91,76 +89,67 @@ namespace NServiceBus.Persistence.RavenDB
         {
             var subscriptionClient = new SubscriptionClient { TransportAddress = subscriber.TransportAddress, Endpoint = subscriber.Endpoint };
 
-            using (var session = OpenAsyncSession())
+            using var session = OpenAsyncSession();
+            var subscriptionDocId = GetDocumentIdForMessageType(messageType);
+
+            var subscription = await session.LoadAsync<Subscription>(subscriptionDocId, cancellationToken).ConfigureAwait(false);
+
+            if (subscription == null)
             {
-                var subscriptionDocId = GetDocumentIdForMessageType(messageType);
-
-                var subscription = await session.LoadAsync<Subscription>(subscriptionDocId, cancellationToken).ConfigureAwait(false);
-
-                if (subscription == null)
-                {
-                    return;
-                }
-
-                if (subscription.Subscribers.Contains(subscriptionClient))
-                {
-                    subscription.Subscribers.Remove(subscriptionClient);
-                }
-
-                await session.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                return;
             }
+
+            if (subscription.Subscribers.Contains(subscriptionClient))
+            {
+                subscription.Subscribers.Remove(subscriptionClient);
+            }
+
+            await session.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes, ContextBag context, CancellationToken cancellationToken = default)
         {
             var ids = messageTypes.Select(GetDocumentIdForMessageType).ToList();
 
-            using (var suppressTransaction = new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled))
+            using var suppressTransaction = new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled);
+            Subscriber[] subscribers;
+            using (var session = OpenAsyncSession())
             {
-                Subscriber[] subscribers;
-                using (var session = OpenAsyncSession())
-                {
-                    var aggressiveCachingScope = await ConfigureAggressiveCaching(session).ConfigureAwait(false);
-                    using (aggressiveCachingScope)
-                    {
-                        var subscriptions = await session.LoadAsync<Subscription>(ids, cancellationToken).ConfigureAwait(false);
+                using IDisposable aggressiveCachingScope = await CreateAggressiveCachingScope(session).ConfigureAwait(false);
+                var subscriptions = await session.LoadAsync<Subscription>(ids, cancellationToken).ConfigureAwait(false);
 
-                        subscribers = subscriptions.Values.Where(s => s != null)
-                            .SelectMany(s => s.Subscribers)
-                            .Distinct()
-                            .Select(c => new Subscriber(c.TransportAddress, c.Endpoint))
-                            .ToArray();
-                    }
-                }
-
-                suppressTransaction.Complete();
-                return subscribers;
+                subscribers = subscriptions.Values.Where(s => s != null)
+                    .SelectMany(s => s.Subscribers)
+                    .Distinct()
+                    .Select(c => new Subscriber(c.TransportAddress, c.Endpoint))
+                    .ToArray();
             }
+
+            suppressTransaction.Complete();
+            return subscribers;
         }
 
         static string GetDocumentIdForMessageType(MessageType messageType)
         {
-            using (var provider = SHA1.Create())
+            using var provider = SHA1.Create();
+            var inputBytes = Encoding.UTF8.GetBytes(messageType.TypeName);
+            var hashBytes = provider.ComputeHash(inputBytes);
+
+            // 54ch for perf - "Subscriptions/" (14ch) + 40ch hash
+            var idBuilder = new StringBuilder(54);
+
+            idBuilder.Append("Subscriptions/");
+
+            for (var i = 0; i < hashBytes.Length; i++)
             {
-                var inputBytes = Encoding.UTF8.GetBytes(messageType.TypeName);
-                var hashBytes = provider.ComputeHash(inputBytes);
-
-                // 54ch for perf - "Subscriptions/" (14ch) + 40ch hash
-                var idBuilder = new StringBuilder(54);
-
-                idBuilder.Append("Subscriptions/");
-
-                for (var i = 0; i < hashBytes.Length; i++)
-                {
-                    idBuilder.Append(hashBytes[i].ToString("x2"));
-                }
-
-                return idBuilder.ToString();
+                idBuilder.Append(hashBytes[i].ToString("x2"));
             }
+
+            return idBuilder.ToString();
         }
 
 #pragma warning disable PS0018
-        ValueTask<IDisposable> ConfigureAggressiveCaching(IAsyncDocumentSession session) =>
+        ValueTask<IDisposable> CreateAggressiveCachingScope(IAsyncDocumentSession session) =>
 #pragma warning restore PS0018
             DisableAggressiveCaching
                 ? new ValueTask<IDisposable>(EmptyDisposable.Instance)


### PR DESCRIPTION
Related to https://github.com/ravendb/ravendb/issues/15378

This switches the subscription persister to the newly AggressiveCachingForAsync to avoid starving thread due to the underlying sync over async in the RavenDB Client.