### PR TITLE
Bump major version to 11

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <MinVerMinimumMajorMinor>10.0</MinVerMinimumMajorMinor>
+    <MinVerMinimumMajorMinor>11.0</MinVerMinimumMajorMinor>
     <MinVerAutoIncrement>minor</MinVerAutoIncrement>
     <LangVersion>preview</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
We need to make room for an NSB 9 release that uses RavenDB.Client 6.x, so we're going to go ahead and let that release be 10.x and make the NSB 10 release be 11.x.

