### PR TITLE
Do not use members removed in RavenDB.Client 7.2.x

### DIFF
--- a/src/NServiceBus.RavenDB/SagaPersister/UnwrappedSagaListener.cs
+++ b/src/NServiceBus.RavenDB/SagaPersister/UnwrappedSagaListener.cs
@@ -31,16 +31,14 @@ static class UnwrappedSagaListener
             return;
         }
 
-        if (!args.Document.TryGetMember("Originator", out _))
+        if (!args.Document.TryGet<object>("Originator", out _))
         {
             // The SagaDataContainer will not have "Originator" but older stored IContainSagaData will
             return;
         }
 
-        if (!args.Document.TryGetMember("@metadata", out var metadataObj) ||
-            metadataObj is not BlittableJsonReaderObject metadata ||
-            !metadata.TryGetMember(Constants.Documents.Metadata.RavenClrType, out var lazyClrType) ||
-            lazyClrType is not LazyStringValue clrType ||
+        if (!args.Document.TryGet<BlittableJsonReaderObject>("@metadata", out var metadata) ||
+            !metadata.TryGet<LazyStringValue>(Constants.Documents.Metadata.RavenClrType, out var clrType) ||
             clrType.ToString() == ContainerTypeName)
         {
             return;


### PR DESCRIPTION
RavenDB.Client 7.2.x removed `TryGetMember(string, out object)` ([somewhere between 7.1.5 and 7.2.1](https://github.com/ravendb/ravendb/compare/7.1.5...7.2.0#diff-e369f221bd22ce32476af1f71eedf88359da21d110397be3e186bd67f70e6156L648-L653)). Since `UnwrappedSagaListener.OnBeforeConversionToEntity` is registered for all entity types, the JIT tries to resolve TryGetMember(string, out object) the first time any entity (Subscription, OutboxRecord, etc.) is converted, even though the early return guards prevent it from being executed for non-saga types.

Use the typed `TryGet<T>(string, out T)`, which exists in both 6.2.13 and [7.2.1](https://github.com/Particular/NServiceBus.RavenDB/pull/1534).

Backported in:

- https://github.com/Particular/NServiceBus.RavenDB/pull/1579
- https://github.com/Particular/NServiceBus.RavenDB/pull/1580