### PR TITLE
[Backport #1554 to v11] Do not use members removed in RavenDB.Client 7.2.x

### DIFF
--- a/src/NServiceBus.RavenDB.AcceptanceTests/NServiceBus.RavenDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.AcceptanceTests/NServiceBus.RavenDB.AcceptanceTests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.0.0" GeneratePathProperty="true" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.0.2" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />

--- a/src/NServiceBus.RavenDB.ClusterWide.AcceptanceTests/NServiceBus.RavenDB.ClusterWide.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.ClusterWide.AcceptanceTests/NServiceBus.RavenDB.ClusterWide.AcceptanceTests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.0.0" GeneratePathProperty="true" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.0.2" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />

--- a/src/NServiceBus.RavenDB.ClusterWide.Latest.AcceptanceTests/NServiceBus.RavenDB.ClusterWide.Latest.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.ClusterWide.Latest.AcceptanceTests/NServiceBus.RavenDB.ClusterWide.Latest.AcceptanceTests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.0.0" GeneratePathProperty="true" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.0.2" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />

--- a/src/NServiceBus.RavenDB.Latest.AcceptanceTests/NServiceBus.RavenDB.Latest.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.Latest.AcceptanceTests/NServiceBus.RavenDB.Latest.AcceptanceTests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.0.0" GeneratePathProperty="true" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.0.2" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />

--- a/src/NServiceBus.RavenDB.Optimistic.AcceptanceTests/NServiceBus.RavenDB.Optimistic.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.Optimistic.AcceptanceTests/NServiceBus.RavenDB.Optimistic.AcceptanceTests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.0.0" GeneratePathProperty="true" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.0.2" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />

--- a/src/NServiceBus.RavenDB.Optimistic.ClusterWide.AcceptanceTests/NServiceBus.RavenDB.Optimistic.ClusterWide.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.Optimistic.ClusterWide.AcceptanceTests/NServiceBus.RavenDB.Optimistic.ClusterWide.AcceptanceTests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.0.0" GeneratePathProperty="true" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.0.2" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />

--- a/src/NServiceBus.RavenDB.Optimistic.ClusterWide.Latest.AcceptanceTests/NServiceBus.RavenDB.Optimistic.ClusterWide.Latest.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.Optimistic.ClusterWide.Latest.AcceptanceTests/NServiceBus.RavenDB.Optimistic.ClusterWide.Latest.AcceptanceTests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.0.0" GeneratePathProperty="true" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.0.2" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />

--- a/src/NServiceBus.RavenDB.Optimistic.Latest.AcceptanceTests/NServiceBus.RavenDB.Optimistic.Latest.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.Optimistic.Latest.AcceptanceTests/NServiceBus.RavenDB.Optimistic.Latest.AcceptanceTests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.0.0" GeneratePathProperty="true" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.0.2" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />

--- a/src/NServiceBus.RavenDB.PersistenceTests/NServiceBus.RavenDB.PersistenceTests.csproj
+++ b/src/NServiceBus.RavenDB.PersistenceTests/NServiceBus.RavenDB.PersistenceTests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NServiceBus.PersistenceTests.Sources" Version="10.0.0" />
+    <PackageReference Include="NServiceBus.PersistenceTests.Sources" Version="10.0.2" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />

--- a/src/NServiceBus.RavenDB.TransactionalSession.AcceptanceTests/NServiceBus.RavenDB.TransactionalSession.AcceptanceTests.csproj
+++ b/src/NServiceBus.RavenDB.TransactionalSession.AcceptanceTests/NServiceBus.RavenDB.TransactionalSession.AcceptanceTests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="10.0.0" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="10.0.2" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />

--- a/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
+++ b/src/NServiceBus.RavenDB/NServiceBus.RavenDB.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Public dependencies">
-    <PackageReference Include="NServiceBus" Version="10.0.0" />
+    <PackageReference Include="NServiceBus" Version="10.0.2" />
     <PackageReference Include="NuGet.Versioning" Version="7.0.1" AutomaticVersionRange="false" />
     <PackageReference Include="RavenDB.Client" Version="6.2.12" AutomaticVersionRange="false" />
   </ItemGroup>

--- a/src/NServiceBus.RavenDB/SagaPersister/UnwrappedSagaListener.cs
+++ b/src/NServiceBus.RavenDB/SagaPersister/UnwrappedSagaListener.cs
@@ -31,16 +31,14 @@ static class UnwrappedSagaListener
             return;
         }
 
-        if (!args.Document.TryGetMember("Originator", out _))
+        if (!args.Document.TryGet<object>("Originator", out _))
         {
             // The SagaDataContainer will not have "Originator" but older stored IContainSagaData will
             return;
         }
 
-        if (!args.Document.TryGetMember("@metadata", out var metadataObj) ||
-            metadataObj is not BlittableJsonReaderObject metadata ||
-            !metadata.TryGetMember(Constants.Documents.Metadata.RavenClrType, out var lazyClrType) ||
-            lazyClrType is not LazyStringValue clrType ||
+        if (!args.Document.TryGet<BlittableJsonReaderObject>("@metadata", out var metadata) ||
+            !metadata.TryGet<LazyStringValue>(Constants.Documents.Metadata.RavenClrType, out var clrType) ||
             clrType.ToString() == ContainerTypeName)
         {
             return;


### PR DESCRIPTION
backport of:

-  #1554

Depends on:

- Fixing the `System.Security.Cryptography.Xml` CVE